### PR TITLE
Specify TypeScript type for .d.ts

### DIFF
--- a/src/readable/sys.rs
+++ b/src/readable/sys.rs
@@ -18,6 +18,7 @@ extern "C" {
     /// [`unchecked_into`][wasm_bindgen::JsCast::unchecked_into].
     ///
     /// [web-sys]: https://docs.rs/web-sys/latest/web_sys/struct.ReadableStream.html
+    #[wasm_bindgen(js_name = ReadableStream, typescript_type = "ReadableStream")]
     #[derive(Clone, Debug)]
     pub type ReadableStream;
 

--- a/src/transform/sys.rs
+++ b/src/transform/sys.rs
@@ -8,6 +8,7 @@ use crate::writable::sys::WritableStream;
 #[wasm_bindgen]
 extern "C" {
     /// A raw [`TransformStream`](https://developer.mozilla.org/en-US/docs/Web/API/TransformStream).
+    #[wasm_bindgen(js_name = TransformStream, typescript_type = "TransformStream")]
     #[derive(Clone, Debug)]
     pub type TransformStream;
 

--- a/src/writable/sys.rs
+++ b/src/writable/sys.rs
@@ -8,6 +8,7 @@ use super::into_underlying_sink::IntoUnderlyingSink;
 #[wasm_bindgen]
 extern "C" {
     /// A raw [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
+    #[wasm_bindgen(js_name = WritableStream, typescript_type = "WritableStream")]
     #[derive(Clone, Debug)]
     pub type WritableStream;
 


### PR DESCRIPTION
Hi, thank you so much for your great work!

## Before PR

Before this pull request, types in auto-generated .d.ts are all `any` as follows.

```ts
/**
* @param {number} num
* @returns {any}
*/
export function myfunc1(num: number): any;
/**
* @param {number} num
* @returns {any}
*/
export function myfunc2(num: number): any;
/**
* @param {number} num
* @returns {any}
*/
export function myfunc3(num: number): any;
```

## After PR

After this pull request, types in .d.ts has more proper types than `any`.
```ts
/**
* @param {number} num
* @returns {ReadableStream}
*/
export function myfunc1(num: number): ReadableStream;
/**
* @param {number} num
* @returns {WritableStream}
*/
export function myfunc2(num: number): WritableStream;
/**
* @param {number} num
* @returns {TransformStream}
*/
export function myfunc3(num: number): TransformStream;
```

### Rust

Here is the source.

```rs
#[wasm_bindgen]
pub fn myfunc1(num: i32) -> wasm_streams::readable::sys::ReadableStream {
    unimplemented!()
}

#[wasm_bindgen]
pub fn myfunc2(num: i32) -> wasm_streams::writable::sys::WritableStream {
    unimplemented!()
}

#[wasm_bindgen]
pub fn myfunc3(num: i32) -> wasm_streams::transform::sys::TransformStream {
    unimplemented!()
}
```

## CI status

Here is CI status in my forked repo.
https://github.com/nwtgck/wasm-streams/actions/runs/200276672