### PR TITLE
Use "async fn" in wasm-bindgen definitions

### DIFF
--- a/src/readable/byob_reader.rs
+++ b/src/readable/byob_reader.rs
@@ -4,7 +4,7 @@ use js_sys::Uint8Array;
 use wasm_bindgen::{throw_val, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 
-use crate::util::{checked_cast_to_usize, clamp_to_u32, promise_to_void_future};
+use crate::util::{checked_cast_to_usize, clamp_to_u32};
 
 use super::{sys, IntoAsyncRead, ReadableStream};
 
@@ -42,7 +42,7 @@ impl<'stream> ReadableStreamBYOBReader<'stream> {
     /// [released](https://streams.spec.whatwg.org/#release-a-lock) before the stream finishes
     /// closing.
     pub async fn closed(&self) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().closed()).await
+        self.as_raw().closed().await
     }
 
     /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
@@ -50,7 +50,7 @@ impl<'stream> ReadableStreamBYOBReader<'stream> {
     ///
     /// Equivalent to [`ReadableStream.cancel`](ReadableStream::cancel).
     pub async fn cancel(&mut self) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().cancel()).await
+        self.as_raw().cancel().await
     }
 
     /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
@@ -58,7 +58,7 @@ impl<'stream> ReadableStreamBYOBReader<'stream> {
     ///
     /// Equivalent to [`ReadableStream.cancel_with_reason`](ReadableStream::cancel_with_reason).
     pub async fn cancel_with_reason(&mut self, reason: &JsValue) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().cancel_with_reason(reason)).await
+        self.as_raw().cancel_with_reason(reason).await
     }
 
     /// Reads the next chunk from the stream's internal queue into `dst`,

--- a/src/readable/default_reader.rs
+++ b/src/readable/default_reader.rs
@@ -3,8 +3,6 @@ use std::marker::PhantomData;
 use wasm_bindgen::{throw_val, JsValue};
 use wasm_bindgen_futures::JsFuture;
 
-use crate::util::promise_to_void_future;
-
 use super::{sys, IntoStream, ReadableStream};
 
 /// A [`ReadableStreamDefaultReader`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader)
@@ -39,7 +37,7 @@ impl<'stream> ReadableStreamDefaultReader<'stream> {
     /// [released](https://streams.spec.whatwg.org/#release-a-lock) before the stream finishes
     /// closing.
     pub async fn closed(&self) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().closed()).await
+        self.as_raw().closed().await
     }
 
     /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
@@ -47,7 +45,7 @@ impl<'stream> ReadableStreamDefaultReader<'stream> {
     ///
     /// Equivalent to [`ReadableStream.cancel`](ReadableStream::cancel).
     pub async fn cancel(&mut self) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().cancel()).await
+        self.as_raw().cancel().await
     }
 
     /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
@@ -55,7 +53,7 @@ impl<'stream> ReadableStreamDefaultReader<'stream> {
     ///
     /// Equivalent to [`ReadableStream.cancel_with_reason`](ReadableStream::cancel_with_reason).
     pub async fn cancel_with_reason(&mut self, reason: &JsValue) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().cancel_with_reason(reason)).await
+        self.as_raw().cancel_with_reason(reason).await
     }
 
     /// Reads the next chunk from the stream's internal queue.

--- a/src/readable/into_async_read.rs
+++ b/src/readable/into_async_read.rs
@@ -138,7 +138,7 @@ impl<'reader> Drop for IntoAsyncRead<'reader> {
     fn drop(&mut self) {
         if self.cancel_on_drop {
             if let Some(reader) = self.reader.take() {
-                let _ = reader.as_raw().cancel().catch(&Closure::once(|_| {}));
+                drop(reader.as_raw().cancel().now_or_never());
             }
         }
     }

--- a/src/readable/into_stream.rs
+++ b/src/readable/into_stream.rs
@@ -109,7 +109,7 @@ impl<'reader> Drop for IntoStream<'reader> {
     fn drop(&mut self) {
         if self.cancel_on_drop {
             if let Some(reader) = self.reader.take() {
-                let _ = reader.as_raw().cancel().catch(&Closure::once(|_| {}));
+                drop(reader.as_raw().cancel().now_or_never());
             }
         }
     }

--- a/src/readable/mod.rs
+++ b/src/readable/mod.rs
@@ -14,7 +14,6 @@ pub use pipe_options::PipeOptions;
 
 use crate::queuing_strategy::QueuingStrategy;
 use crate::readable::into_underlying_byte_source::IntoUnderlyingByteSource;
-use crate::util::promise_to_void_future;
 use crate::writable::WritableStream;
 
 mod byob_reader;
@@ -119,7 +118,7 @@ impl ReadableStream {
     ///
     /// If the stream is currently locked to a reader, then this returns an error.
     pub async fn cancel(&mut self) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().cancel()).await
+        self.as_raw().cancel().await
     }
 
     /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
@@ -129,7 +128,7 @@ impl ReadableStream {
     ///
     /// If the stream is currently locked to a reader, then this returns an error.
     pub async fn cancel_with_reason(&mut self, reason: &JsValue) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().cancel_with_reason(reason)).await
+        self.as_raw().cancel_with_reason(reason).await
     }
 
     /// Creates a [default reader](ReadableStreamDefaultReader) and
@@ -216,10 +215,9 @@ impl ReadableStream {
         dest: &'a mut WritableStream,
         options: &PipeOptions,
     ) -> Result<(), JsValue> {
-        let promise = self
-            .as_raw()
-            .pipe_to(dest.as_raw(), options.clone().into_raw());
-        promise_to_void_future(promise).await
+        self.as_raw()
+            .pipe_to(dest.as_raw(), options.clone().into_raw())
+            .await
     }
 
     /// [Tees](https://streams.spec.whatwg.org/#tee-a-readable-stream) this readable stream,

--- a/src/readable/sys.rs
+++ b/src/readable/sys.rs
@@ -41,11 +41,12 @@ extern "C" {
     #[wasm_bindgen(method, getter, js_name = locked)]
     pub fn is_locked(this: &ReadableStream) -> bool;
 
-    #[wasm_bindgen(method, js_name = cancel)]
-    pub fn cancel(this: &ReadableStream) -> Promise;
+    #[wasm_bindgen(method, catch, js_name = cancel)]
+    pub async fn cancel(this: &ReadableStream) -> Result<(), JsValue>;
 
-    #[wasm_bindgen(method, js_name = cancel)]
-    pub fn cancel_with_reason(this: &ReadableStream, reason: &JsValue) -> Promise;
+    #[wasm_bindgen(method, catch, js_name = cancel)]
+    pub async fn cancel_with_reason(this: &ReadableStream, reason: &JsValue)
+        -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, catch, js_name = getReader)]
     pub fn get_reader(this: &ReadableStream) -> Result<ReadableStreamDefaultReader, Error>;
@@ -56,8 +57,12 @@ extern "C" {
         opts: ReadableStreamGetReaderOptions,
     ) -> Result<ReadableStreamBYOBReader, Error>;
 
-    #[wasm_bindgen(method, js_name = pipeTo)]
-    pub fn pipe_to(this: &ReadableStream, dest: &WritableStream, opts: PipeOptions) -> Promise;
+    #[wasm_bindgen(method, catch, js_name = pipeTo)]
+    pub async fn pipe_to(
+        this: &ReadableStream,
+        dest: &WritableStream,
+        opts: PipeOptions,
+    ) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, catch, js_name = tee)]
     pub fn tee(this: &ReadableStream) -> Result<Array, Error>;
@@ -142,14 +147,17 @@ extern "C" {
     #[derive(Clone, Debug)]
     pub type ReadableStreamGenericReader;
 
-    #[wasm_bindgen(method, getter, js_name = closed)]
-    pub fn closed(this: &ReadableStreamGenericReader) -> Promise;
+    #[wasm_bindgen(method, getter, catch, js_name = closed)]
+    pub async fn closed(this: &ReadableStreamGenericReader) -> Result<(), JsValue>;
 
-    #[wasm_bindgen(method, js_name = cancel)]
-    pub fn cancel(this: &ReadableStreamGenericReader) -> Promise;
+    #[wasm_bindgen(method, catch, js_name = cancel)]
+    pub async fn cancel(this: &ReadableStreamGenericReader) -> Result<(), JsValue>;
 
-    #[wasm_bindgen(method, js_name = cancel)]
-    pub fn cancel_with_reason(this: &ReadableStreamGenericReader, reason: &JsValue) -> Promise;
+    #[wasm_bindgen(method, catch, js_name = cancel)]
+    pub async fn cancel_with_reason(
+        this: &ReadableStreamGenericReader,
+        reason: &JsValue,
+    ) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, catch, js_name = releaseLock)]
     pub fn release_lock(this: &ReadableStreamGenericReader) -> Result<(), Error>;

--- a/src/writable/default_writer.rs
+++ b/src/writable/default_writer.rs
@@ -38,7 +38,7 @@ impl<'stream> WritableStreamDefaultWriter<'stream> {
     /// [released](https://streams.spec.whatwg.org/#release-a-lock) before the stream finishes
     /// closing.
     pub async fn closed(&self) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().closed()).await
+        self.as_raw().closed().await
     }
 
     /// Returns the desired size to fill the stream's internal queue.
@@ -71,7 +71,7 @@ impl<'stream> WritableStreamDefaultWriter<'stream> {
     ///
     /// Equivalent to [`WritableStream.abort`](WritableStream::abort).
     pub async fn abort(&mut self) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().abort()).await
+        self.as_raw().abort().await
     }
 
     /// [Aborts](https://streams.spec.whatwg.org/#abort-a-writable-stream) the stream with the
@@ -79,7 +79,7 @@ impl<'stream> WritableStreamDefaultWriter<'stream> {
     ///
     /// Equivalent to [`WritableStream.abort_with_reason`](WritableStream::abort_with_reason).
     pub async fn abort_with_reason(&mut self, reason: &JsValue) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().abort_with_reason(reason)).await
+        self.as_raw().abort_with_reason(reason).await
     }
 
     /// Writes the given `chunk` to the writable stream, by waiting until any previous writes

--- a/src/writable/mod.rs
+++ b/src/writable/mod.rs
@@ -9,8 +9,6 @@ pub use into_async_write::IntoAsyncWrite;
 pub use into_sink::IntoSink;
 use into_underlying_sink::IntoUnderlyingSink;
 
-use crate::util::promise_to_void_future;
-
 mod default_writer;
 mod into_async_write;
 mod into_sink;
@@ -82,7 +80,7 @@ impl WritableStream {
     ///
     /// If the stream is currently locked to a writer, then this returns an error.
     pub async fn abort(&mut self) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().abort()).await
+        self.as_raw().abort().await
     }
 
     /// [Aborts](https://streams.spec.whatwg.org/#abort-a-writable-stream) the stream with the
@@ -91,7 +89,7 @@ impl WritableStream {
     ///
     /// If the stream is currently locked to a writer, then this returns an error.
     pub async fn abort_with_reason(&mut self, reason: &JsValue) -> Result<(), JsValue> {
-        promise_to_void_future(self.as_raw().abort_with_reason(reason)).await
+        self.as_raw().abort_with_reason(reason).await
     }
 
     /// Creates a [writer](WritableStreamDefaultWriter) and

--- a/src/writable/sys.rs
+++ b/src/writable/sys.rs
@@ -21,11 +21,11 @@ extern "C" {
     #[wasm_bindgen(method, getter, js_name = locked)]
     pub fn is_locked(this: &WritableStream) -> bool;
 
-    #[wasm_bindgen(method, js_name = abort)]
-    pub fn abort(this: &WritableStream) -> Promise;
+    #[wasm_bindgen(method, catch, js_name = abort)]
+    pub async fn abort(this: &WritableStream) -> Result<(), JsValue>;
 
-    #[wasm_bindgen(method, js_name = abort)]
-    pub fn abort_with_reason(this: &WritableStream, reason: &JsValue) -> Promise;
+    #[wasm_bindgen(method, catch, js_name = abort)]
+    pub async fn abort_with_reason(this: &WritableStream, reason: &JsValue) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, catch, js_name = getWriter)]
     pub fn get_writer(this: &WritableStream) -> Result<WritableStreamDefaultWriter, Error>;
@@ -37,8 +37,8 @@ extern "C" {
     #[derive(Clone, Debug)]
     pub type WritableStreamDefaultWriter;
 
-    #[wasm_bindgen(method, getter, js_name = closed)]
-    pub fn closed(this: &WritableStreamDefaultWriter) -> Promise;
+    #[wasm_bindgen(method, getter, catch, js_name = closed)]
+    pub async fn closed(this: &WritableStreamDefaultWriter) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, getter, js_name = desiredSize)]
     pub fn desired_size(this: &WritableStreamDefaultWriter) -> Option<f64>;
@@ -46,11 +46,14 @@ extern "C" {
     #[wasm_bindgen(method, getter, js_name = ready)]
     pub fn ready(this: &WritableStreamDefaultWriter) -> Promise;
 
-    #[wasm_bindgen(method, js_name = abort)]
-    pub fn abort(this: &WritableStreamDefaultWriter) -> Promise;
+    #[wasm_bindgen(method, catch, js_name = abort)]
+    pub async fn abort(this: &WritableStreamDefaultWriter) -> Result<(), JsValue>;
 
-    #[wasm_bindgen(method, js_name = abort)]
-    pub fn abort_with_reason(this: &WritableStreamDefaultWriter, reason: &JsValue) -> Promise;
+    #[wasm_bindgen(method, catch, js_name = abort)]
+    pub async fn abort_with_reason(
+        this: &WritableStreamDefaultWriter,
+        reason: &JsValue,
+    ) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, js_name = close)]
     pub fn close(this: &WritableStreamDefaultWriter) -> Promise;


### PR DESCRIPTION
`wasm-bindgen` now supports `async fn` inside the `extern` definitions, which automatically turns the `Promise` into an `impl Future`. This removes the need for (most) manual conversions.

However, this does not yet seem to work with `rustfmt`: it removes the `async` keywords, which breaks the code. 😕

Also, the `IntoUnderlyingSource` and `IntoUnderlyingSink` implementations need to store a `JsFuture` in their `struct`, so they cannot use `impl Future`. Well, at least not until RFC 2515 (_"Permit impl Trait in type aliases"_) lands... 😛