### PR TITLE
Automatically cancel IntoStream and IntoAsyncRead when dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* `ReadableStream::into_stream()` and `ReadableStream::into_async_read()` now automatically 
+  cancel the stream when dropped ([#7](https://github.com/MattiasBuelens/wasm-streams/issues/7), [#8](https://github.com/MattiasBuelens/wasm-streams/pull/8))
+* Added `IntoStream::cancel()` and `IntoAsyncRead::cancel()` ([#8](https://github.com/MattiasBuelens/wasm-streams/pull/8))
+
 ## v0.2.0 (2021-06-22)
 
 * Add support for readable byte streams ([#6](https://github.com/MattiasBuelens/wasm-streams/pull/6))

--- a/src/readable/byob_reader.rs
+++ b/src/readable/byob_reader.rs
@@ -179,7 +179,7 @@ impl<'stream> ReadableStreamBYOBReader<'stream> {
     /// allowing another reader to read the remaining bytes later on.
     #[inline]
     pub fn into_async_read(self) -> IntoAsyncRead<'stream> {
-        IntoAsyncRead::new(self)
+        IntoAsyncRead::new(self, false)
     }
 }
 

--- a/src/readable/byob_reader.rs
+++ b/src/readable/byob_reader.rs
@@ -14,6 +14,9 @@ use super::{sys, IntoAsyncRead, ReadableStream};
 /// This is returned by the [`get_byob_reader`](ReadableStream::get_byob_reader) method.
 ///
 /// When the reader is dropped, it automatically [releases its lock](https://streams.spec.whatwg.org/#release-a-lock).
+/// If the reader still has a pending read request at this point (i.e. if a future returned
+/// by [`read`](Self::read) is not yet ready), then this will **panic**. You must either `await`
+/// all `read` futures, or [`cancel`](Self::cancel) the stream to discard any pending `read` futures.
 #[derive(Debug)]
 pub struct ReadableStreamBYOBReader<'stream> {
     raw: sys::ReadableStreamBYOBReader,

--- a/src/readable/default_reader.rs
+++ b/src/readable/default_reader.rs
@@ -13,6 +13,9 @@ use super::{sys, IntoStream, ReadableStream};
 /// This is returned by the [`get_reader`](ReadableStream::get_reader) method.
 ///
 /// When the reader is dropped, it automatically [releases its lock](https://streams.spec.whatwg.org/#release-a-lock).
+/// If the reader still has a pending read request at this point (i.e. if a future returned
+/// by [`read`](Self::read) is not yet ready), then this will **panic**. You must either `await`
+/// all `read` futures, or [`cancel`](Self::cancel) the stream to discard any pending `read` futures.
 #[derive(Debug)]
 pub struct ReadableStreamDefaultReader<'stream> {
     raw: sys::ReadableStreamDefaultReader,

--- a/src/readable/default_reader.rs
+++ b/src/readable/default_reader.rs
@@ -113,7 +113,7 @@ impl<'stream> ReadableStreamDefaultReader<'stream> {
     /// another reader to read the remaining chunks later on.
     #[inline]
     pub fn into_stream(self) -> IntoStream<'stream> {
-        IntoStream::new(self)
+        IntoStream::new(self, false)
     }
 }
 

--- a/src/readable/into_async_read.rs
+++ b/src/readable/into_async_read.rs
@@ -50,19 +50,19 @@ impl<'reader> IntoAsyncRead<'reader> {
     /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
     /// signaling a loss of interest in the stream by a consumer.
     pub async fn cancel(mut self) -> Result<(), JsValue> {
-        if let Some(mut reader) = self.reader.take() {
-            reader.cancel().await?
+        match self.reader.take() {
+            Some(mut reader) => reader.cancel().await,
+            None => Ok(()),
         }
-        Ok(())
     }
 
     /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
     /// signaling a loss of interest in the stream by a consumer.
     pub async fn cancel_with_reason(mut self, reason: &JsValue) -> Result<(), JsValue> {
-        if let Some(mut reader) = self.reader.take() {
-            reader.cancel_with_reason(reason).await?
+        match self.reader.take() {
+            Some(mut reader) => reader.cancel_with_reason(reason).await,
+            None => Ok(()),
         }
-        Ok(())
     }
 
     #[inline]

--- a/src/readable/into_async_read.rs
+++ b/src/readable/into_async_read.rs
@@ -38,6 +38,24 @@ impl<'reader> IntoAsyncRead<'reader> {
         }
     }
 
+    /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
+    /// signaling a loss of interest in the stream by a consumer.
+    pub async fn cancel(mut self) -> Result<(), JsValue> {
+        if let Some(mut reader) = self.reader.take() {
+            reader.cancel().await?
+        }
+        Ok(())
+    }
+
+    /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
+    /// signaling a loss of interest in the stream by a consumer.
+    pub async fn cancel_with_reason(mut self, reason: &JsValue) -> Result<(), JsValue> {
+        if let Some(mut reader) = self.reader.take() {
+            reader.cancel_with_reason(reason).await?
+        }
+        Ok(())
+    }
+
     #[inline]
     fn discard_reader(mut self: Pin<&mut Self>) {
         self.reader = None;

--- a/src/readable/into_stream.rs
+++ b/src/readable/into_stream.rs
@@ -12,22 +12,31 @@ use super::ReadableStreamDefaultReader;
 
 /// A [`Stream`](futures::Stream) for the [`into_stream`](super::ReadableStream::into_stream) method.
 ///
-/// This stream holds a reader, and therefore locks the [`ReadableStream`](super::ReadableStream).
-/// When this stream is dropped, it also drops its reader which in turn
+/// This `Stream` holds a reader, and therefore locks the [`ReadableStream`](super::ReadableStream).
+/// When this `Stream` is dropped, it also drops its reader which in turn
 /// [releases its lock](https://streams.spec.whatwg.org/#release-a-lock).
+///
+/// When used through [`ReadableStream::into_stream`](super::ReadableStream::into_stream),
+/// the stream is automatically cancelled before dropping the reader, discarding any pending read requests.
+/// When used through [`ReadableStreamDefaultReader::into_stream`](super::ReadableStreamDefaultReader::into_stream),
+/// it is up to the user to either manually [cancel](Self::cancel) the stream,
+/// or to ensure that there are no pending read requests when dropped.
+/// See the documentation on [`ReadableStreamDefaultReader`] for more details on the drop behavior.
 #[must_use = "streams do nothing unless polled"]
 #[derive(Debug)]
 pub struct IntoStream<'reader> {
     reader: Option<ReadableStreamDefaultReader<'reader>>,
     fut: Option<JsFuture>,
+    cancel_on_drop: bool,
 }
 
 impl<'reader> IntoStream<'reader> {
     #[inline]
-    pub(super) fn new(reader: ReadableStreamDefaultReader) -> IntoStream {
+    pub(super) fn new(reader: ReadableStreamDefaultReader, cancel_on_drop: bool) -> IntoStream {
         IntoStream {
             reader: Some(reader),
             fut: None,
+            cancel_on_drop,
         }
     }
 
@@ -97,5 +106,15 @@ impl<'reader> Stream for IntoStream<'reader> {
                 Some(Err(js_value))
             }
         })
+    }
+}
+
+impl<'reader> Drop for IntoStream<'reader> {
+    fn drop(&mut self) {
+        if self.cancel_on_drop {
+            if let Some(reader) = self.reader.take() {
+                let _ = reader.as_raw().cancel().catch(&Closure::once(|_| {}));
+            }
+        }
     }
 }

--- a/src/readable/into_stream.rs
+++ b/src/readable/into_stream.rs
@@ -43,19 +43,19 @@ impl<'reader> IntoStream<'reader> {
     /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
     /// signaling a loss of interest in the stream by a consumer.
     pub async fn cancel(mut self) -> Result<(), JsValue> {
-        if let Some(mut reader) = self.reader.take() {
-            reader.cancel().await?
+        match self.reader.take() {
+            Some(mut reader) => reader.cancel().await,
+            None => Ok(()),
         }
-        Ok(())
     }
 
     /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
     /// signaling a loss of interest in the stream by a consumer.
     pub async fn cancel_with_reason(mut self, reason: &JsValue) -> Result<(), JsValue> {
-        if let Some(mut reader) = self.reader.take() {
-            reader.cancel_with_reason(reason).await?
+        match self.reader.take() {
+            Some(mut reader) => reader.cancel_with_reason(reason).await,
+            None => Ok(()),
         }
-        Ok(())
     }
 }
 

--- a/src/readable/into_stream.rs
+++ b/src/readable/into_stream.rs
@@ -30,6 +30,24 @@ impl<'reader> IntoStream<'reader> {
             fut: None,
         }
     }
+
+    /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
+    /// signaling a loss of interest in the stream by a consumer.
+    pub async fn cancel(mut self) -> Result<(), JsValue> {
+        if let Some(mut reader) = self.reader.take() {
+            reader.cancel().await?
+        }
+        Ok(())
+    }
+
+    /// [Cancels](https://streams.spec.whatwg.org/#cancel-a-readable-stream) the stream,
+    /// signaling a loss of interest in the stream by a consumer.
+    pub async fn cancel_with_reason(mut self, reason: &JsValue) -> Result<(), JsValue> {
+        if let Some(mut reader) = self.reader.take() {
+            reader.cancel_with_reason(reason).await?
+        }
+        Ok(())
+    }
 }
 
 impl FusedStream for IntoStream<'_> {

--- a/src/readable/mod.rs
+++ b/src/readable/mod.rs
@@ -283,7 +283,7 @@ impl ReadableStream {
     /// along with the original `ReadableStream`.
     pub fn try_into_stream(mut self) -> Result<IntoStream<'static>, (js_sys::Error, Self)> {
         let reader = ReadableStreamDefaultReader::new(&mut self).map_err(|err| (err, self))?;
-        Ok(reader.into_stream())
+        Ok(IntoStream::new(reader, true))
     }
 
     /// Converts this `ReadableStream` into an [`AsyncRead`](futures::io::AsyncRead).
@@ -302,7 +302,7 @@ impl ReadableStream {
     /// stream, then this returns an error along with the original `ReadableStream`.
     pub fn try_into_async_read(mut self) -> Result<IntoAsyncRead<'static>, (js_sys::Error, Self)> {
         let reader = ReadableStreamBYOBReader::new(&mut self).map_err(|err| (err, self))?;
-        Ok(reader.into_async_read())
+        Ok(IntoAsyncRead::new(reader, true))
     }
 }
 


### PR DESCRIPTION
Fixes #7.