### PR TITLE
Add WritableStream::into_async_write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+* Added `WritableStream::into_async_write()` to turn a `WritableStream` accepting `Uint8Array`s 
+  into an `AsyncWrite` ([#9](https://github.com/MattiasBuelens/wasm-streams/issues/9),
+  [#10](https://github.com/MattiasBuelens/wasm-streams/pull/10))
+* Added `IntoSink::abort()` ([#10](https://github.com/MattiasBuelens/wasm-streams/pull/10))
+
 ## v0.2.1 (2021-09-23)
 
 * `ReadableStream::into_stream()` and `ReadableStream::into_async_read()` now automatically 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ js-sys = "^0.3.47"
 wasm-bindgen = "0.2.73"
 wasm-bindgen-futures = "^0.4.20"
 futures = "^0.3.12"
-pin-project-lite = "^0.2.7"
 
 [dependencies.web-sys]
 version = "^0.3.47"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ js-sys = "^0.3.47"
 wasm-bindgen = "0.2.73"
 wasm-bindgen-futures = "^0.4.20"
 futures = "^0.3.12"
+pin-project-lite = "^0.2.7"
 
 [dependencies.web-sys]
 version = "^0.3.47"

--- a/src/readable/into_async_read.rs
+++ b/src/readable/into_async_read.rs
@@ -115,14 +115,13 @@ impl<'reader> AsyncRead for IntoAsyncRead<'reader> {
         Poll::Ready(match js_result {
             Ok(js_value) => {
                 let result = ReadableStreamBYOBReadResult::from(js_value);
-                let filled_view = result.value();
                 if result.is_done() {
                     // End of stream
                     self.discard_reader();
                     Ok(0)
                 } else {
                     // Cannot be canceled, so view must exist
-                    let filled_view = filled_view.unwrap_throw();
+                    let filled_view = result.value().unwrap_throw();
                     // Copy bytes to output buffer
                     let filled_len = checked_cast_to_usize(filled_view.byte_length());
                     debug_assert!(filled_len <= buf.len());

--- a/src/readable/into_async_read.rs
+++ b/src/readable/into_async_read.rs
@@ -27,7 +27,7 @@ use super::ReadableStreamBYOBReader;
 /// it is up to the user to either manually [cancel](Self::cancel) the stream,
 /// or to ensure that there are no pending read requests when dropped.
 /// See the documentation on [`ReadableStreamBYOBReader`] for more details on the drop behavior.
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "readers do nothing unless polled"]
 #[derive(Debug)]
 pub struct IntoAsyncRead<'reader> {
     reader: Option<ReadableStreamBYOBReader<'reader>>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -40,3 +40,15 @@ pub(crate) fn checked_cast_to_usize(value: u32) -> usize {
     debug_assert_eq!(value, wrapped as u32);
     wrapped
 }
+
+pub(crate) fn js_to_io_error(js_value: JsValue) -> std::io::Error {
+    let message = get_error_message(js_value).unwrap_or_else(|| "Unknown error".to_string());
+    std::io::Error::new(std::io::ErrorKind::Other, message)
+}
+
+fn get_error_message(js_value: JsValue) -> Option<String> {
+    js_value.as_string().or_else(|| {
+        js_sys::Object::try_from(&js_value)
+            .map(|js_object| js_object.to_string().as_string().unwrap_throw())
+    })
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -42,13 +42,13 @@ pub(crate) fn checked_cast_to_usize(value: u32) -> usize {
 }
 
 pub(crate) fn js_to_io_error(js_value: JsValue) -> std::io::Error {
-    let message = get_error_message(js_value).unwrap_or_else(|| "Unknown error".to_string());
+    let message = js_to_string(&js_value).unwrap_or_else(|| "Unknown error".to_string());
     std::io::Error::new(std::io::ErrorKind::Other, message)
 }
 
-fn get_error_message(js_value: JsValue) -> Option<String> {
+fn js_to_string(js_value: &JsValue) -> Option<String> {
     js_value.as_string().or_else(|| {
-        js_sys::Object::try_from(&js_value)
+        js_sys::Object::try_from(js_value)
             .map(|js_object| js_object.to_string().as_string().unwrap_throw())
     })
 }

--- a/src/writable/default_writer.rs
+++ b/src/writable/default_writer.rs
@@ -119,6 +119,14 @@ impl<'stream> WritableStreamDefaultWriter<'stream> {
         IntoSink::new(self)
     }
 
+    /// Converts this `WritableStreamDefaultWriter` into an [`AsyncWrite`](futures::AsyncWrite).
+    ///
+    /// The writable stream must accept [`Uint8Array`](js_sys::Uint8Array) chunks.
+    ///
+    /// This is similar to [`WritableStream.into_async_write`](WritableStream::into_async_write),
+    /// except that after the returned `AsyncWrite` is dropped, the original `WritableStream` is
+    /// still usable. This allows writing only a few bytes through the `AsyncWrite`, while still
+    /// allowing another writer to write more bytes later on.
     #[inline]
     pub fn into_async_write(self) -> IntoAsyncWrite<'stream> {
         IntoAsyncWrite::new(self.into_sink())

--- a/src/writable/default_writer.rs
+++ b/src/writable/default_writer.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::JsValue;
 
 use crate::util::promise_to_void_future;
 
-use super::{sys, IntoSink, WritableStream};
+use super::{sys, IntoAsyncWrite, IntoSink, WritableStream};
 
 /// A [`WritableStreamDefaultWriter`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter)
 /// that can be used to write chunks to a [`WritableStream`](WritableStream).
@@ -117,6 +117,11 @@ impl<'stream> WritableStreamDefaultWriter<'stream> {
     #[inline]
     pub fn into_sink(self) -> IntoSink<'stream> {
         IntoSink::new(self)
+    }
+
+    #[inline]
+    pub fn into_async_write(self) -> IntoAsyncWrite<'stream> {
+        IntoAsyncWrite::new(self.into_sink())
     }
 }
 

--- a/src/writable/into_async_write.rs
+++ b/src/writable/into_async_write.rs
@@ -1,0 +1,50 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::io::AsyncWrite;
+use futures::ready;
+use futures::sink::Sink;
+use pin_project_lite::pin_project;
+
+pin_project! {
+    #[derive(Debug)]
+    #[must_use = "writers do nothing unless polled"]
+    pub struct IntoAsyncWrite<Si>
+    {
+        #[pin]
+        sink: Si
+    }
+}
+
+impl<Si> IntoAsyncWrite<Si> {
+    #[inline]
+    pub(super) fn new(sink: Si) -> Self {
+        Self { sink }
+    }
+}
+
+impl<Si> AsyncWrite for IntoAsyncWrite<Si>
+where
+    Si: Sink<Box<[u8]>, Error = std::io::Error>,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let mut this = self.project();
+        ready!(this.sink.as_mut().poll_ready(cx))?;
+        this.sink.as_mut().start_send(buf.into())?; // buf.into() makes a copy
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let mut this = self.project();
+        this.sink.as_mut().poll_flush(cx).map_ok(|_| ())
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let mut this = self.project();
+        this.sink.as_mut().poll_close(cx).map_ok(|_| ())
+    }
+}

--- a/src/writable/into_async_write.rs
+++ b/src/writable/into_async_write.rs
@@ -3,22 +3,17 @@ use std::task::{Context, Poll};
 
 use futures::io::AsyncWrite;
 use futures::ready;
-use futures::sink::Sink;
+use futures::sink::SinkExt;
 use js_sys::Uint8Array;
-use pin_project_lite::pin_project;
 
 use crate::util::js_to_io_error;
 
 use super::IntoSink;
 
-pin_project! {
-    #[derive(Debug)]
-    #[must_use = "writers do nothing unless polled"]
-    pub struct IntoAsyncWrite<'writer>
-    {
-        #[pin]
-        sink: IntoSink<'writer>
-    }
+#[derive(Debug)]
+#[must_use = "writers do nothing unless polled"]
+pub struct IntoAsyncWrite<'writer> {
+    sink: IntoSink<'writer>,
 }
 
 impl<'writer> IntoAsyncWrite<'writer> {
@@ -30,33 +25,34 @@ impl<'writer> IntoAsyncWrite<'writer> {
 
 impl<'writer> AsyncWrite for IntoAsyncWrite<'writer> {
     fn poll_write(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        let mut this = self.project();
-        ready!(this.sink.as_mut().poll_ready(cx).map_err(js_to_io_error))?;
-        this.sink
+        ready!(self
             .as_mut()
-            .start_send(Uint8Array::from(buf).into())
+            .sink
+            .poll_ready_unpin(cx)
+            .map_err(js_to_io_error))?;
+        self.as_mut()
+            .sink
+            .start_send_unpin(Uint8Array::from(buf).into())
             .map_err(js_to_io_error)?;
         Poll::Ready(Ok(buf.len()))
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        let mut this = self.project();
-        this.sink
-            .as_mut()
-            .poll_flush(cx)
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.as_mut()
+            .sink
+            .poll_flush_unpin(cx)
             .map_ok(|_| ())
             .map_err(js_to_io_error)
     }
 
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        let mut this = self.project();
-        this.sink
-            .as_mut()
-            .poll_close(cx)
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.as_mut()
+            .sink
+            .poll_close_unpin(cx)
             .map_ok(|_| ())
             .map_err(js_to_io_error)
     }

--- a/src/writable/into_async_write.rs
+++ b/src/writable/into_async_write.rs
@@ -10,8 +10,13 @@ use crate::util::js_to_io_error;
 
 use super::IntoSink;
 
-#[derive(Debug)]
+/// An [`AsyncWrite`](futures::AsyncWrite) for the [`into_async_write`](super::WritableStream::into_async_write) method.
+///
+/// This `AsyncWrite` holds a writer, and therefore locks the [`WritableStream`](super::WritableStream).
+/// When this `AsyncWrite` is dropped, it also drops its writer which in turn
+/// [releases its lock](https://streams.spec.whatwg.org/#release-a-lock).
 #[must_use = "writers do nothing unless polled"]
+#[derive(Debug)]
 pub struct IntoAsyncWrite<'writer> {
     sink: IntoSink<'writer>,
 }

--- a/src/writable/into_async_write.rs
+++ b/src/writable/into_async_write.rs
@@ -4,47 +4,60 @@ use std::task::{Context, Poll};
 use futures::io::AsyncWrite;
 use futures::ready;
 use futures::sink::Sink;
+use js_sys::Uint8Array;
 use pin_project_lite::pin_project;
+
+use crate::util::js_to_io_error;
+
+use super::IntoSink;
 
 pin_project! {
     #[derive(Debug)]
     #[must_use = "writers do nothing unless polled"]
-    pub struct IntoAsyncWrite<Si>
+    pub struct IntoAsyncWrite<'writer>
     {
         #[pin]
-        sink: Si
+        sink: IntoSink<'writer>
     }
 }
 
-impl<Si> IntoAsyncWrite<Si> {
+impl<'writer> IntoAsyncWrite<'writer> {
     #[inline]
-    pub(super) fn new(sink: Si) -> Self {
+    pub(super) fn new(sink: IntoSink<'writer>) -> Self {
         Self { sink }
     }
 }
 
-impl<Si> AsyncWrite for IntoAsyncWrite<Si>
-where
-    Si: Sink<Box<[u8]>, Error = std::io::Error>,
-{
+impl<'writer> AsyncWrite for IntoAsyncWrite<'writer> {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
         let mut this = self.project();
-        ready!(this.sink.as_mut().poll_ready(cx))?;
-        this.sink.as_mut().start_send(buf.into())?; // buf.into() makes a copy
+        ready!(this.sink.as_mut().poll_ready(cx).map_err(js_to_io_error))?;
+        this.sink
+            .as_mut()
+            .start_send(Uint8Array::from(buf).into())
+            .map_err(js_to_io_error)?;
         Poll::Ready(Ok(buf.len()))
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
         let mut this = self.project();
-        this.sink.as_mut().poll_flush(cx).map_ok(|_| ())
+        this.sink
+            .as_mut()
+            .poll_flush(cx)
+            .map_ok(|_| ())
+            .map_err(js_to_io_error)
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
         let mut this = self.project();
-        this.sink.as_mut().poll_close(cx).map_ok(|_| ())
+        this.sink
+            .as_mut()
+            .poll_close(cx)
+            .map_ok(|_| ())
+            .map_err(js_to_io_error)
     }
 }

--- a/src/writable/into_async_write.rs
+++ b/src/writable/into_async_write.rs
@@ -5,6 +5,7 @@ use futures::io::AsyncWrite;
 use futures::ready;
 use futures::sink::SinkExt;
 use js_sys::Uint8Array;
+use wasm_bindgen::JsValue;
 
 use crate::util::js_to_io_error;
 
@@ -25,6 +26,18 @@ impl<'writer> IntoAsyncWrite<'writer> {
     #[inline]
     pub(super) fn new(sink: IntoSink<'writer>) -> Self {
         Self { sink }
+    }
+
+    /// [Aborts](https://streams.spec.whatwg.org/#abort-a-writable-stream) the stream,
+    /// signaling that the producer can no longer successfully write to the stream.
+    pub async fn abort(self) -> Result<(), JsValue> {
+        self.sink.abort().await
+    }
+
+    /// [Aborts](https://streams.spec.whatwg.org/#abort-a-writable-stream) the stream,
+    /// signaling that the producer can no longer successfully write to the stream.
+    pub async fn abort_with_reason(self, reason: &JsValue) -> Result<(), JsValue> {
+        self.sink.abort_with_reason(reason).await
     }
 }
 

--- a/src/writable/into_async_write.rs
+++ b/src/writable/into_async_write.rs
@@ -45,7 +45,6 @@ impl<'writer> AsyncWrite for IntoAsyncWrite<'writer> {
         self.as_mut()
             .sink
             .poll_flush_unpin(cx)
-            .map_ok(|_| ())
             .map_err(js_to_io_error)
     }
 
@@ -53,7 +52,6 @@ impl<'writer> AsyncWrite for IntoAsyncWrite<'writer> {
         self.as_mut()
             .sink
             .poll_close_unpin(cx)
-            .map_ok(|_| ())
             .map_err(js_to_io_error)
     }
 }

--- a/src/writable/into_sink.rs
+++ b/src/writable/into_sink.rs
@@ -58,29 +58,24 @@ impl<'writer> Sink<JsValue> for IntoSink<'writer> {
     type Error = JsValue;
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if self.ready_fut.is_none() {
-            // No pending ready future yet
-            match &self.writer {
+        let ready_fut = match self.ready_fut.as_mut() {
+            Some(fut) => fut,
+            None => match &self.writer {
                 Some(writer) => {
-                    // Create future for ready promise
+                    // No pending ready future yet, create one from ready promise
                     let fut = JsFuture::from(writer.as_raw().ready());
-                    self.ready_fut = Some(fut);
+                    self.ready_fut.insert(fut)
                 }
                 None => {
                     // Writer was already dropped
                     // TODO Return error?
                     return Poll::Ready(Ok(()));
                 }
-            }
-        }
+            },
+        };
 
         // Poll the ready future
-        let js_result = ready!(self
-            .as_mut()
-            .ready_fut
-            .as_mut()
-            .unwrap_throw()
-            .poll_unpin(cx));
+        let js_result = ready!(ready_fut.poll_unpin(cx));
         self.ready_fut = None;
 
         // Ready future completed
@@ -113,18 +108,16 @@ impl<'writer> Sink<JsValue> for IntoSink<'writer> {
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // If we're not writing, then there's nothing to flush
-        if self.write_fut.is_none() {
-            return Poll::Ready(Ok(()));
-        }
+        let write_fut = match self.write_fut.as_mut() {
+            Some(fut) => fut,
+            None => {
+                // If we're not writing, then there's nothing to flush
+                return Poll::Ready(Ok(()));
+            }
+        };
 
         // Poll the write future
-        let js_result = ready!(self
-            .as_mut()
-            .write_fut
-            .as_mut()
-            .unwrap_throw()
-            .poll_unpin(cx));
+        let js_result = ready!(write_fut.poll_unpin(cx));
         self.write_fut = None;
 
         // Write future completed
@@ -142,29 +135,25 @@ impl<'writer> Sink<JsValue> for IntoSink<'writer> {
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if self.close_fut.is_none() {
-            // No pending close future, start closing the stream
-            match &self.writer {
+        let close_fut = match self.close_fut.as_mut() {
+            Some(fut) => fut,
+            None => match &self.writer {
                 Some(writer) => {
-                    // Create future for close promise
+                    // No pending close future
+                    // Start closing the stream and create future from close promise
                     let fut = JsFuture::from(writer.as_raw().close());
-                    self.close_fut = Some(fut);
+                    self.close_fut.insert(fut)
                 }
                 None => {
                     // Writer was already dropped
                     // TODO Return error?
                     return Poll::Ready(Ok(()));
                 }
-            }
-        }
+            },
+        };
 
         // Poll the close future
-        let js_result = ready!(self
-            .as_mut()
-            .close_fut
-            .as_mut()
-            .unwrap_throw()
-            .poll_unpin(cx));
+        let js_result = ready!(close_fut.poll_unpin(cx));
         self.close_fut = None;
 
         // Close future completed

--- a/src/writable/into_sink.rs
+++ b/src/writable/into_sink.rs
@@ -34,6 +34,24 @@ impl<'writer> IntoSink<'writer> {
             close_fut: None,
         }
     }
+
+    /// [Aborts](https://streams.spec.whatwg.org/#abort-a-writable-stream) the stream,
+    /// signaling that the producer can no longer successfully write to the stream.
+    pub async fn abort(mut self) -> Result<(), JsValue> {
+        match self.writer.take() {
+            Some(mut writer) => writer.abort().await,
+            None => Ok(()),
+        }
+    }
+
+    /// [Aborts](https://streams.spec.whatwg.org/#abort-a-writable-stream) the stream,
+    /// signaling that the producer can no longer successfully write to the stream.
+    pub async fn abort_with_reason(mut self, reason: &JsValue) -> Result<(), JsValue> {
+        match self.writer.take() {
+            Some(mut writer) => writer.abort_with_reason(reason).await,
+            None => Ok(()),
+        }
+    }
 }
 
 impl<'writer> Sink<JsValue> for IntoSink<'writer> {

--- a/src/writable/into_sink.rs
+++ b/src/writable/into_sink.rs
@@ -59,7 +59,7 @@ impl<'writer> Sink<JsValue> for IntoSink<'writer> {
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         if self.ready_fut.is_none() {
-            // No pending ready future, start reading the next chunk
+            // No pending ready future yet
             match &self.writer {
                 Some(writer) => {
                     // Create future for ready promise

--- a/src/writable/into_sink.rs
+++ b/src/writable/into_sink.rs
@@ -14,6 +14,8 @@ use super::WritableStreamDefaultWriter;
 /// This sink holds a writer, and therefore locks the [`WritableStream`](super::WritableStream).
 /// When this sink is dropped, it also drops its writer which in turn
 /// [releases its lock](https://streams.spec.whatwg.org/#release-a-lock).
+/// TODO
+#[must_use = "sinks do nothing unless polled"]
 #[derive(Debug)]
 pub struct IntoSink<'writer> {
     writer: Option<WritableStreamDefaultWriter<'writer>>,

--- a/src/writable/mod.rs
+++ b/src/writable/mod.rs
@@ -5,11 +5,11 @@ use futures::Sink;
 use wasm_bindgen::prelude::*;
 
 pub use default_writer::WritableStreamDefaultWriter;
+pub use into_async_write::IntoAsyncWrite;
 pub use into_sink::IntoSink;
 use into_underlying_sink::IntoUnderlyingSink;
 
 use crate::util::promise_to_void_future;
-use crate::writable::into_async_write::IntoAsyncWrite;
 
 mod default_writer;
 mod into_async_write;

--- a/src/writable/mod.rs
+++ b/src/writable/mod.rs
@@ -140,11 +140,23 @@ impl WritableStream {
         Ok(writer.into_sink())
     }
 
+    /// Converts this `WritableStream` into an [`AsyncWrite`](futures::AsyncWrite).
+    ///
+    /// The writable stream must accept [`Uint8Array`](js_sys::Uint8Array) chunks.
+    ///
+    /// **Panics** if the stream is already locked to a writer. For a non-panicking variant,
+    /// use [`try_into_async_write`](Self::try_into_async_write).
     pub fn into_async_write(self) -> IntoAsyncWrite<'static> {
         self.try_into_async_write()
             .expect_throw("already locked to a writer")
     }
 
+    /// Try to convert this `WritableStream` into an [`AsyncWrite`](futures::AsyncWrite).
+    ///
+    /// The writable stream must accept [`Uint8Array`](js_sys::Uint8Array) chunks.
+    ///
+    /// If the stream is already locked to a writer, then this returns an error
+    /// along with the original `WritableStream`.
     pub fn try_into_async_write(self) -> Result<IntoAsyncWrite<'static>, (js_sys::Error, Self)> {
         Ok(IntoAsyncWrite::new(self.try_into_sink()?))
     }

--- a/tests/js/writable_stream.js
+++ b/tests/js/writable_stream.js
@@ -2,18 +2,22 @@ export function new_noop_writable_stream() {
     return new WritableStream();
 }
 
+const TYPE_WRITE = 0;
+const TYPE_CLOSE = 1;
+const TYPE_ABORT = 2;
+
 export function new_recording_writable_stream() {
     const events = [];
     const stream = new WritableStream({
         write(chunk) {
-            events.push("write", chunk);
+            events.push({type: TYPE_WRITE, chunk});
         },
         close() {
-            events.push("close");
+            events.push({type: TYPE_CLOSE});
         },
-        abort(e) {
-            events.push("abort", e);
+        abort(reason) {
+            events.push({type: TYPE_ABORT, reason});
         }
     });
     return {stream, events};
-};
+}

--- a/tests/js/writable_stream.rs
+++ b/tests/js/writable_stream.rs
@@ -51,7 +51,7 @@ impl RecordingWritableStream {
     pub fn events(&self) -> Vec<RecordedEvent> {
         self.raw
             .events()
-            .into_iter()
+            .iter()
             .map(|x| RecordedEvent::from(x.unchecked_ref::<JsRecordedEvent>()))
             .collect::<Vec<_>>()
     }
@@ -81,7 +81,7 @@ impl PartialEq for RecordedEvent {
                 if left_val.eq(right_val) {
                     true
                 } else {
-                    equal_uint8_array(&left_val, &right_val)
+                    equal_uint8_array(left_val, right_val)
                 }
             }
             (RecordedEvent::Close, RecordedEvent::Close) => true,

--- a/tests/js/writable_stream.rs
+++ b/tests/js/writable_stream.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Debug, Formatter};
+
 use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -55,7 +57,6 @@ impl RecordingWritableStream {
     }
 }
 
-#[derive(Debug)]
 pub enum RecordedEvent {
     Write(JsValue),
     Close,
@@ -96,5 +97,23 @@ fn equal_uint8_array(left: &JsValue, right: &JsValue) -> bool {
     match (left.dyn_ref::<Uint8Array>(), right.dyn_ref::<Uint8Array>()) {
         (Some(left_array), Some(right_array)) => left_array.to_vec().eq(&right_array.to_vec()),
         _ => false,
+    }
+}
+
+impl Debug for RecordedEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RecordedEvent::Write(value) => {
+                let mut tuple = f.debug_tuple("Write");
+                if let Some(array) = value.dyn_ref::<Uint8Array>() {
+                    tuple.field(&array.to_vec())
+                } else {
+                    tuple.field(value)
+                };
+                tuple.finish()
+            }
+            RecordedEvent::Close => f.debug_tuple("Close").finish(),
+            RecordedEvent::Abort(value) => f.debug_tuple("Abort").field(value).finish(),
+        }
     }
 }

--- a/tests/js/writable_stream.rs
+++ b/tests/js/writable_stream.rs
@@ -36,7 +36,14 @@ impl RecordingWritableStream {
         self.raw
             .events()
             .into_iter()
-            .map(|x| x.as_string().unwrap())
+            .map(|x| js_to_string(x).expect_throw("not a string or object"))
             .collect::<Vec<_>>()
     }
+}
+
+fn js_to_string(js_value: &JsValue) -> Option<String> {
+    js_value.as_string().or_else(|| {
+        js_sys::Object::try_from(js_value)
+            .map(|js_object| js_object.to_string().as_string().unwrap_throw())
+    })
 }

--- a/tests/js/writable_stream.rs
+++ b/tests/js/writable_stream.rs
@@ -1,4 +1,6 @@
+use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 
 use wasm_streams::writable::*;
 
@@ -15,6 +17,18 @@ extern "C" {
 
     #[wasm_bindgen(method, getter)]
     fn events(this: &WritableStreamAndEvents) -> Box<[JsValue]>;
+
+    #[derive(Clone, Debug)]
+    type JsRecordedEvent;
+
+    #[wasm_bindgen(method, getter, js_name = "type")]
+    fn type_(this: &JsRecordedEvent) -> u8;
+
+    #[wasm_bindgen(method, getter)]
+    fn chunk(this: &JsRecordedEvent) -> JsValue;
+
+    #[wasm_bindgen(method, getter)]
+    fn reason(this: &JsRecordedEvent) -> JsValue;
 }
 
 pub struct RecordingWritableStream {
@@ -32,18 +46,55 @@ impl RecordingWritableStream {
         self.raw.stream()
     }
 
-    pub fn events(&self) -> Vec<String> {
+    pub fn events(&self) -> Vec<RecordedEvent> {
         self.raw
             .events()
             .into_iter()
-            .map(|x| js_to_string(x).expect_throw("not a string or object"))
+            .map(|x| RecordedEvent::from(x.unchecked_ref::<JsRecordedEvent>()))
             .collect::<Vec<_>>()
     }
 }
 
-fn js_to_string(js_value: &JsValue) -> Option<String> {
-    js_value.as_string().or_else(|| {
-        js_sys::Object::try_from(js_value)
-            .map(|js_object| js_object.to_string().as_string().unwrap_throw())
-    })
+#[derive(Debug)]
+pub enum RecordedEvent {
+    Write(JsValue),
+    Close,
+    Abort(JsValue),
+}
+
+impl From<&JsRecordedEvent> for RecordedEvent {
+    fn from(js_event: &JsRecordedEvent) -> Self {
+        match js_event.type_() {
+            0 => RecordedEvent::Write(js_event.chunk()),
+            1 => RecordedEvent::Close,
+            2 => RecordedEvent::Abort(js_event.reason()),
+            event_type => panic!("unknown event type: {}", event_type),
+        }
+    }
+}
+
+impl PartialEq for RecordedEvent {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (RecordedEvent::Write(left_val), RecordedEvent::Write(right_val)) => {
+                if left_val.eq(right_val) {
+                    true
+                } else {
+                    equal_uint8_array(&left_val, &right_val)
+                }
+            }
+            (RecordedEvent::Close, RecordedEvent::Close) => true,
+            (RecordedEvent::Abort(left_val), RecordedEvent::Abort(right_val)) => {
+                left_val.eq(right_val)
+            }
+            _ => false,
+        }
+    }
+}
+
+fn equal_uint8_array(left: &JsValue, right: &JsValue) -> bool {
+    match (left.dyn_ref::<Uint8Array>(), right.dyn_ref::<Uint8Array>()) {
+        (Some(left_array), Some(right_array)) => left_array.to_vec().eq(&right_array.to_vec()),
+        _ => false,
+    }
 }

--- a/tests/tests/pipe.rs
+++ b/tests/tests/pipe.rs
@@ -44,7 +44,7 @@ async fn test_pipe_rust_to_js() {
     // All chunks must be sent to sink
     assert_eq!(
         recording_stream.events(),
-        vec![
+        [
             RecordedEvent::Write(JsValue::from("Hello")),
             RecordedEvent::Write(JsValue::from("world!")),
             RecordedEvent::Close
@@ -74,7 +74,7 @@ async fn test_pipe_prevent_close() {
     // All chunks must be sent to sink, without closing it
     assert_eq!(
         recording_stream.events(),
-        vec![
+        [
             RecordedEvent::Write(JsValue::from("Hello")),
             RecordedEvent::Write(JsValue::from("world!"))
         ]

--- a/tests/tests/pipe.rs
+++ b/tests/tests/pipe.rs
@@ -44,7 +44,11 @@ async fn test_pipe_rust_to_js() {
     // All chunks must be sent to sink
     assert_eq!(
         recording_stream.events(),
-        vec!["write", "Hello", "write", "world!", "close"]
+        vec![
+            RecordedEvent::Write(JsValue::from("Hello")),
+            RecordedEvent::Write(JsValue::from("world!")),
+            RecordedEvent::Close
+        ]
     );
 
     // Both streams must be closed
@@ -70,7 +74,10 @@ async fn test_pipe_prevent_close() {
     // All chunks must be sent to sink, without closing it
     assert_eq!(
         recording_stream.events(),
-        vec!["write", "Hello", "write", "world!"]
+        vec![
+            RecordedEvent::Write(JsValue::from("Hello")),
+            RecordedEvent::Write(JsValue::from("world!"))
+        ]
     );
 
     // Readable stream must be closed

--- a/tests/tests/readable_byte_stream.rs
+++ b/tests/tests/readable_byte_stream.rs
@@ -111,7 +111,7 @@ async fn test_readable_byte_stream_byob_reader_into_async_read() {
     assert!(!readable.is_locked());
 
     {
-        // Acquire a BYOB reader and wrap it in a Rust stream
+        // Acquire a BYOB reader and wrap it in a Rust Stream
         let reader = readable.get_byob_reader();
         let mut async_read = reader.into_async_read();
 
@@ -120,11 +120,11 @@ async fn test_readable_byte_stream_byob_reader_into_async_read() {
         assert_eq!(&buf, &[1, 2, 3]);
     }
 
-    // Dropping the wrapped stream should release the lock
+    // Dropping the wrapped Stream should release the lock
     assert!(!readable.is_locked());
 
     {
-        // Can acquire a new reader after wrapped stream is dropped
+        // Can acquire a new reader after wrapped Stream is dropped
         let mut reader = readable.get_byob_reader();
         let mut buf = [0u8; 3];
         assert_eq!(reader.read(&mut buf).await.unwrap(), 3);

--- a/tests/tests/readable_byte_stream.rs
+++ b/tests/tests/readable_byte_stream.rs
@@ -263,7 +263,7 @@ async fn test_readable_byte_stream_into_async_read_auto_cancel() {
 
     // Stream must be unlocked and cancelled
     let mut readable = ReadableStream::from_raw(raw_readable);
-    assert_eq!(readable.is_locked(), false);
+    assert!(!readable.is_locked());
     let mut reader = readable.get_reader();
     assert_eq!(reader.read().await.unwrap(), None);
 }
@@ -289,7 +289,7 @@ async fn test_readable_byte_stream_into_async_read_manual_cancel() {
 
     // Stream must be unlocked and cancelled
     let mut readable = ReadableStream::from_raw(raw_readable);
-    assert_eq!(readable.is_locked(), false);
+    assert!(!readable.is_locked());
     let mut reader = readable.get_reader();
     assert_eq!(reader.read().await.unwrap(), None);
 }

--- a/tests/tests/readable_stream.rs
+++ b/tests/tests/readable_stream.rs
@@ -58,14 +58,14 @@ async fn test_readable_stream_reader_into_stream() {
     assert!(!readable.is_locked());
 
     {
-        // Acquire a reader and wrap it in a Rust stream
+        // Acquire a reader and wrap it in a Rust Stream
         let reader = readable.get_reader();
         let mut stream = reader.into_stream();
 
         assert_eq!(stream.next().await, Some(Ok(JsValue::from("Hello"))));
     }
 
-    // Dropping the wrapped stream should release the lock
+    // Dropping the wrapped Stream should release the lock
     assert!(!readable.is_locked());
 
     {

--- a/tests/tests/readable_stream.rs
+++ b/tests/tests/readable_stream.rs
@@ -1,9 +1,12 @@
 use std::pin::Pin;
 
+use futures::io::AsyncReadExt;
 use futures::stream::{iter, pending, StreamExt, TryStreamExt};
 use futures::task::Poll;
 use futures::{poll, FutureExt};
+use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 use wasm_streams::readable::*;
@@ -240,4 +243,31 @@ async fn test_readable_stream_into_stream_manual_cancel() {
     assert_eq!(readable.is_locked(), false);
     let mut reader = readable.get_reader();
     assert_eq!(reader.read().await.unwrap(), None);
+}
+
+#[wasm_bindgen_test]
+async fn test_readable_stream_into_stream_then_into_async_read() {
+    let mut readable = ReadableStream::from_raw(new_readable_stream_from_array(
+        vec![
+            Uint8Array::from(&[1, 2, 3][..]).into(),
+            Uint8Array::from(&[4, 5, 6][..]).into(),
+        ]
+        .into_boxed_slice(),
+    ));
+    assert!(!readable.is_locked());
+
+    let mut async_read = readable
+        .into_stream()
+        .map_ok(|value| value.dyn_into::<Uint8Array>().unwrap().to_vec())
+        .map_err(|err| std::io::Error::from(std::io::ErrorKind::Other))
+        .into_async_read();
+    let mut buf = [0u8; 3];
+    assert_eq!(async_read.read(&mut buf).await.unwrap(), 3);
+    assert_eq!(&buf, &[1, 2, 3]);
+    assert_eq!(async_read.read(&mut buf[..1]).await.unwrap(), 1);
+    assert_eq!(&buf, &[4, 2, 3]);
+    assert_eq!(async_read.read(&mut buf[1..]).await.unwrap(), 2);
+    assert_eq!(&buf, &[4, 5, 6]);
+    assert_eq!(async_read.read(&mut buf).await.unwrap(), 0);
+    assert_eq!(&buf, &[4, 5, 6]);
 }

--- a/tests/tests/writable_stream.rs
+++ b/tests/tests/writable_stream.rs
@@ -177,3 +177,11 @@ async fn test_writable_stream_into_async_write() {
         ]
     );
 }
+
+#[wasm_bindgen_test]
+fn test_writable_stream_into_async_write_impl_unpin() {
+    let writable = WritableStream::from_raw(new_noop_writable_stream());
+    let async_write: IntoAsyncWrite = writable.into_async_write();
+
+    let _ = Pin::new(&async_write); // must be Unpin for this to work
+}

--- a/tests/tests/writable_stream.rs
+++ b/tests/tests/writable_stream.rs
@@ -17,9 +17,9 @@ async fn test_writable_stream_new() {
     assert!(!writable.is_locked());
 
     let mut writer = writable.get_writer();
-    assert_eq!(writer.write(JsValue::from("Hello")).await.unwrap(), ());
-    assert_eq!(writer.write(JsValue::from("world!")).await.unwrap(), ());
-    assert_eq!(writer.close().await.unwrap(), ());
+    assert_eq!(writer.write(JsValue::from("Hello")).await, Ok(()));
+    assert_eq!(writer.write(JsValue::from("world!")).await, Ok(()));
+    assert_eq!(writer.close().await, Ok(()));
     writer.closed().await.unwrap();
 }
 
@@ -78,8 +78,8 @@ async fn test_writable_stream_writer_into_sink() {
     {
         // Can acquire a new writer after wrapped sink is dropped
         let mut writer = writable.get_writer();
-        assert_eq!(writer.write(JsValue::from("world!")).await.unwrap(), ());
-        assert_eq!(writer.close().await.unwrap(), ());
+        assert_eq!(writer.write(JsValue::from("world!")).await, Ok(()));
+        assert_eq!(writer.close().await, Ok(()));
     }
 
     assert_eq!(
@@ -99,9 +99,9 @@ async fn test_writable_stream_from_sink() {
     let mut writable = WritableStream::from_sink(sink);
 
     let mut writer = writable.get_writer();
-    assert_eq!(writer.write(JsValue::from("Hello")).await.unwrap(), ());
-    assert_eq!(writer.write(JsValue::from("world!")).await.unwrap(), ());
-    assert_eq!(writer.close().await.unwrap(), ());
+    assert_eq!(writer.write(JsValue::from("Hello")).await, Ok(()));
+    assert_eq!(writer.write(JsValue::from("world!")).await, Ok(()));
+    assert_eq!(writer.close().await, Ok(()));
     writer.closed().await.unwrap();
 
     let output = stream.collect::<Vec<_>>().await;
@@ -165,7 +165,7 @@ async fn test_writable_stream_into_async_write() {
     assert_eq!(async_write.write(&buf).await.unwrap(), 3);
     buf = [7, 8, 9];
     assert_eq!(async_write.write(&buf[0..2]).await.unwrap(), 2);
-    assert_eq!(async_write.close().await.unwrap(), ());
+    async_write.close().await.unwrap();
 
     assert_eq!(
         recording_stream.events(),

--- a/tests/tests/writable_stream.rs
+++ b/tests/tests/writable_stream.rs
@@ -60,7 +60,7 @@ async fn test_writable_stream_writer_into_sink() {
     assert!(!writable.is_locked());
 
     {
-        // Acquire a writer and wrap it in a Rust sink
+        // Acquire a writer and wrap it in a Rust Sink
         let writer = writable.get_writer();
         let mut sink = writer.into_sink();
 
@@ -72,11 +72,11 @@ async fn test_writable_stream_writer_into_sink() {
         [RecordedEvent::Write(JsValue::from("Hello")),]
     );
 
-    // Dropping the wrapped sink should release the lock
+    // Dropping the wrapped Sink should release the lock
     assert!(!writable.is_locked());
 
     {
-        // Can acquire a new writer after wrapped sink is dropped
+        // Can acquire a new writer after wrapped Sink is dropped
         let mut writer = writable.get_writer();
         assert_eq!(writer.write(JsValue::from("world!")).await, Ok(()));
         assert_eq!(writer.close().await, Ok(()));

--- a/tests/tests/writable_stream.rs
+++ b/tests/tests/writable_stream.rs
@@ -161,9 +161,9 @@ async fn test_writable_stream_into_async_write() {
 
     let mut buf = [1, 2, 3];
     assert_eq!(async_write.write(&buf).await.unwrap(), 3);
-    *(&mut buf) = [4, 5, 6];
+    buf = [4, 5, 6];
     assert_eq!(async_write.write(&buf).await.unwrap(), 3);
-    *(&mut buf) = [7, 8, 9];
+    buf = [7, 8, 9];
     assert_eq!(async_write.write(&buf[0..2]).await.unwrap(), 2);
     assert_eq!(async_write.close().await.unwrap(), ());
 

--- a/tests/tests/writable_stream.rs
+++ b/tests/tests/writable_stream.rs
@@ -37,7 +37,7 @@ async fn test_writable_stream_into_sink() {
 
     assert_eq!(
         recording_stream.events(),
-        vec![
+        [
             RecordedEvent::Write(JsValue::from("Hello")),
             RecordedEvent::Write(JsValue::from("world!")),
             RecordedEvent::Close
@@ -69,7 +69,7 @@ async fn test_writable_stream_writer_into_sink() {
 
     assert_eq!(
         recording_stream.events(),
-        vec![RecordedEvent::Write(JsValue::from("Hello")),]
+        [RecordedEvent::Write(JsValue::from("Hello")),]
     );
 
     // Dropping the wrapped sink should release the lock
@@ -84,7 +84,7 @@ async fn test_writable_stream_writer_into_sink() {
 
     assert_eq!(
         recording_stream.events(),
-        vec![
+        [
             RecordedEvent::Write(JsValue::from("Hello")),
             RecordedEvent::Write(JsValue::from("world!")),
             RecordedEvent::Close
@@ -143,7 +143,7 @@ async fn test_writable_stream_multiple_writers() {
 
     assert_eq!(
         recording_stream.events(),
-        vec![
+        [
             RecordedEvent::Write(JsValue::from("Hello")),
             RecordedEvent::Write(JsValue::from("world!")),
             RecordedEvent::Close
@@ -169,7 +169,7 @@ async fn test_writable_stream_into_async_write() {
 
     assert_eq!(
         recording_stream.events(),
-        vec![
+        [
             RecordedEvent::Write(Uint8Array::from(&[1, 2, 3][..]).into()),
             RecordedEvent::Write(Uint8Array::from(&[4, 5, 6][..]).into()),
             RecordedEvent::Write(Uint8Array::from(&[7, 8][..]).into()),

--- a/tests/tests/writable_stream.rs
+++ b/tests/tests/writable_stream.rs
@@ -37,7 +37,11 @@ async fn test_writable_stream_into_sink() {
 
     assert_eq!(
         recording_stream.events(),
-        vec!["write", "Hello", "write", "world!", "close"]
+        vec![
+            RecordedEvent::Write(JsValue::from("Hello")),
+            RecordedEvent::Write(JsValue::from("world!")),
+            RecordedEvent::Close
+        ]
     );
 }
 
@@ -63,7 +67,10 @@ async fn test_writable_stream_writer_into_sink() {
         assert_eq!(sink.send(JsValue::from("Hello")).await, Ok(()));
     }
 
-    assert_eq!(recording_stream.events(), vec!["write", "Hello"]);
+    assert_eq!(
+        recording_stream.events(),
+        vec![RecordedEvent::Write(JsValue::from("Hello")),]
+    );
 
     // Dropping the wrapped sink should release the lock
     assert!(!writable.is_locked());
@@ -77,7 +84,11 @@ async fn test_writable_stream_writer_into_sink() {
 
     assert_eq!(
         recording_stream.events(),
-        vec!["write", "Hello", "write", "world!", "close"]
+        vec![
+            RecordedEvent::Write(JsValue::from("Hello")),
+            RecordedEvent::Write(JsValue::from("world!")),
+            RecordedEvent::Close
+        ]
     );
 }
 
@@ -132,7 +143,11 @@ async fn test_writable_stream_multiple_writers() {
 
     assert_eq!(
         recording_stream.events(),
-        vec!["write", "Hello", "write", "world!", "close"]
+        vec![
+            RecordedEvent::Write(JsValue::from("Hello")),
+            RecordedEvent::Write(JsValue::from("world!")),
+            RecordedEvent::Close
+        ]
     );
 }
 
@@ -154,6 +169,11 @@ async fn test_writable_stream_into_async_write() {
 
     assert_eq!(
         recording_stream.events(),
-        vec!["write", "1,2,3", "write", "4,5,6", "write", "7,8", "close"]
+        vec![
+            RecordedEvent::Write(Uint8Array::from(&[1, 2, 3][..]).into()),
+            RecordedEvent::Write(Uint8Array::from(&[4, 5, 6][..]).into()),
+            RecordedEvent::Write(Uint8Array::from(&[7, 8][..]).into()),
+            RecordedEvent::Close
+        ]
     );
 }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -1,0 +1,1 @@
+pub mod util;

--- a/tests/util/byte_channel.rs
+++ b/tests/util/byte_channel.rs
@@ -128,4 +128,20 @@ mod tests {
         )
         .await;
     }
+
+    #[tokio::test]
+    async fn test_close_then_read() {
+        let channel = ByteChannel::new();
+        let (mut reader, mut writer) = channel.split();
+
+        writer.write_all(&[1, 2, 3]).await.unwrap();
+        writer.close().await.unwrap();
+
+        // should still read bytes from queue
+        let mut read_buf = [0u8; 3];
+        assert_eq!(reader.read(&mut read_buf).await.unwrap(), 3);
+        assert_eq!(&read_buf, &[1, 2, 3]);
+        // should read EOF
+        assert_eq!(reader.read(&mut read_buf).await.unwrap(), 0);
+    }
 }

--- a/tests/util/byte_channel.rs
+++ b/tests/util/byte_channel.rs
@@ -1,0 +1,131 @@
+use std::cmp::min;
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+
+use futures::{AsyncRead, AsyncWrite};
+
+pub struct ByteChannel {
+    queue: VecDeque<u8>,
+    waker: Option<Waker>,
+    closed: bool,
+}
+
+impl ByteChannel {
+    pub fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+            waker: None,
+            closed: false,
+        }
+    }
+}
+
+impl AsyncRead for ByteChannel {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        if self.queue.is_empty() && self.closed {
+            return Poll::Ready(Ok(0));
+        }
+        let num_read = min(self.queue.len(), buf.len());
+        if num_read == 0 {
+            self.waker = Some(cx.waker().clone());
+            return Poll::Pending;
+        }
+        buf.iter_mut()
+            .zip(self.queue.drain(0..num_read))
+            .for_each(|(dst, src)| *dst = src);
+        Poll::Ready(Ok(num_read))
+    }
+}
+
+impl AsyncWrite for ByteChannel {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        self.queue.extend(buf.iter());
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.closed = true;
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::future::join;
+    use futures::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_write_then_read() {
+        let channel = ByteChannel::new();
+        let (mut reader, mut writer) = channel.split();
+
+        let mut read_buf = [0u8; 3];
+        writer.write_all(&[1, 2, 3, 4]).await.unwrap();
+        assert_eq!(reader.read(&mut read_buf).await.unwrap(), 3);
+        assert_eq!(&read_buf, &[1, 2, 3]);
+
+        writer.write_all(&[5, 6]).await.unwrap();
+        assert_eq!(reader.read(&mut read_buf).await.unwrap(), 3);
+        assert_eq!(&read_buf, &[4, 5, 6]);
+
+        writer.close().await.unwrap();
+        assert_eq!(reader.read(&mut read_buf).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_read_then_write() {
+        let channel = ByteChannel::new();
+        let (mut reader, mut writer) = channel.split();
+
+        join(
+            async {
+                let mut read_buf = [0u8; 3];
+                assert_eq!(reader.read(&mut read_buf).await.unwrap(), 3);
+                assert_eq!(&read_buf, &[1, 2, 3]);
+            },
+            async {
+                writer.write_all(&[1, 2, 3, 4]).await.unwrap();
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_read_then_close() {
+        let channel = ByteChannel::new();
+        let (mut reader, mut writer) = channel.split();
+
+        join(
+            async {
+                let mut read_buf = [0u8; 3];
+                assert_eq!(reader.read(&mut read_buf).await.unwrap(), 0);
+                assert_eq!(&read_buf, &[0, 0, 0]);
+            },
+            async {
+                writer.close().await.unwrap();
+            },
+        )
+        .await;
+    }
+}

--- a/tests/util/byte_channel.rs
+++ b/tests/util/byte_channel.rs
@@ -77,17 +77,17 @@ mod tests {
         let channel = ByteChannel::new();
         let (mut reader, mut writer) = channel.split();
 
-        let mut read_buf = [0u8; 3];
+        let mut buf = [0u8; 3];
         writer.write_all(&[1, 2, 3, 4]).await.unwrap();
-        assert_eq!(reader.read(&mut read_buf).await.unwrap(), 3);
-        assert_eq!(&read_buf, &[1, 2, 3]);
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 3);
+        assert_eq!(&buf, &[1, 2, 3]);
 
         writer.write_all(&[5, 6]).await.unwrap();
-        assert_eq!(reader.read(&mut read_buf).await.unwrap(), 3);
-        assert_eq!(&read_buf, &[4, 5, 6]);
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 3);
+        assert_eq!(&buf, &[4, 5, 6]);
 
         writer.close().await.unwrap();
-        assert_eq!(reader.read(&mut read_buf).await.unwrap(), 0);
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 0);
     }
 
     #[tokio::test]
@@ -97,9 +97,9 @@ mod tests {
 
         join(
             async {
-                let mut read_buf = [0u8; 3];
-                assert_eq!(reader.read(&mut read_buf).await.unwrap(), 3);
-                assert_eq!(&read_buf, &[1, 2, 3]);
+                let mut buf = [0u8; 3];
+                assert_eq!(reader.read(&mut buf).await.unwrap(), 3);
+                assert_eq!(&buf, &[1, 2, 3]);
             },
             async {
                 writer.write_all(&[1, 2, 3, 4]).await.unwrap();
@@ -115,9 +115,9 @@ mod tests {
 
         join(
             async {
-                let mut read_buf = [0u8; 3];
-                assert_eq!(reader.read(&mut read_buf).await.unwrap(), 0);
-                assert_eq!(&read_buf, &[0, 0, 0]);
+                let mut buf = [0u8; 3];
+                assert_eq!(reader.read(&mut buf).await.unwrap(), 0);
+                assert_eq!(&buf, &[0, 0, 0]);
             },
             async {
                 writer.close().await.unwrap();
@@ -135,11 +135,11 @@ mod tests {
         writer.close().await.unwrap();
 
         // should still read bytes from queue
-        let mut read_buf = [0u8; 3];
-        assert_eq!(reader.read(&mut read_buf).await.unwrap(), 3);
-        assert_eq!(&read_buf, &[1, 2, 3]);
+        let mut buf = [0u8; 3];
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 3);
+        assert_eq!(&buf, &[1, 2, 3]);
         // should read EOF
-        assert_eq!(reader.read(&mut read_buf).await.unwrap(), 0);
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 0);
     }
 
     #[tokio::test]
@@ -147,7 +147,7 @@ mod tests {
         let channel = ByteChannel::new();
         let (mut reader, _writer) = channel.split();
 
-        let mut read_buf = [0u8; 0];
-        assert_eq!(reader.read(&mut read_buf).await.unwrap(), 0);
+        let mut buf = [0u8; 0];
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 0);
     }
 }

--- a/tests/util/byte_channel.rs
+++ b/tests/util/byte_channel.rs
@@ -5,6 +5,7 @@ use std::task::{Context, Poll, Waker};
 
 use futures::{AsyncRead, AsyncWrite};
 
+#[derive(Debug, Default)]
 pub struct ByteChannel {
     queue: VecDeque<u8>,
     waker: Option<Waker>,
@@ -13,11 +14,7 @@ pub struct ByteChannel {
 
 impl ByteChannel {
     pub fn new() -> Self {
-        Self {
-            queue: VecDeque::new(),
-            waker: None,
-            closed: false,
-        }
+        Self::default()
     }
 }
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,3 +1,5 @@
+pub use byte_channel::ByteChannel;
 pub use drop_observer::observe_drop;
 
+pub mod byte_channel;
 pub mod drop_observer;


### PR DESCRIPTION
This adds a way to turn a JS `WritableStream` into a Rust [`AsyncWrite`](https://docs.rs/futures/0.3.18/futures/io/trait.AsyncWrite.html).

Note that `AsyncWrite` passes a borrowed byte slice (`&'a [u8]`) to `poll_write`, whereas a `WritableStream` expects an "owned" `Uint8Array`. Therefore, we need to copy each given slice into a newly allocated `Uint8Array`. There's currently no way to avoid this copy, since JS doesn't yet have a concept of "writable byte streams" with BYOB semantics. (When such a concept is added in the future, we should be able to update our `AsyncWrite` implementation to use such a BYOB writer instead.)

Fixes #9.