### PR TITLE
Deps: significantly improve compilation times by removing the `futures` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["cdylib", "rlib"]
 js-sys = "^0.3.47"
 wasm-bindgen = "0.2.73"
 wasm-bindgen-futures = "^0.4.20"
-futures-util = { version = "0.3.21", default-features = false, features = ["alloc", "async-await-macro", "io", "sink"] }
+futures-util = { version = "0.3.21", features = ["io", "sink"] }
 
 [dependencies.web-sys]
 version = "^0.3.47"
@@ -29,7 +29,12 @@ features = [
 ]
 
 [dev-dependencies]
-futures-channel = "0.3.21"
+# TODO: Investigate why using `futures-channel` does not work.
+# In theory, there is no reason why `futures` is required here.
+# The `futures-channel` is sufficient for the test cases, but
+# the code does not compile unless we use the channels from the
+# `futures` crate, which are just re-exported from `futures-channel`!
+futures = { version = "0.3.21", default-features = false, features = ["std"] }
 wasm-bindgen-test = "0.3.20"
 tokio = { version = "^1", features = ["macros", "rt"] }
 pin-project = "^1.0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ crate-type = ["cdylib", "rlib"]
 js-sys = "^0.3.47"
 wasm-bindgen = "0.2.73"
 wasm-bindgen-futures = "^0.4.20"
-futures = "^0.3.12"
+futures-channel = "0.3.21"
+futures-util = { version = "0.3.21", default-features = false, features = ["alloc", "async-await-macro", "io", "sink"] }
 
 [dependencies.web-sys]
 version = "^0.3.47"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ crate-type = ["cdylib", "rlib"]
 js-sys = "^0.3.47"
 wasm-bindgen = "0.2.73"
 wasm-bindgen-futures = "^0.4.20"
-futures-channel = "0.3.21"
 futures-util = { version = "0.3.21", default-features = false, features = ["alloc", "async-await-macro", "io", "sink"] }
 
 [dependencies.web-sys]
@@ -30,6 +29,7 @@ features = [
 ]
 
 [dev-dependencies]
+futures-channel = "0.3.21"
 wasm-bindgen-test = "0.3.20"
 tokio = { version = "^1", features = ["macros", "rt"] }
 pin-project = "^1.0.6"

--- a/examples/fetch_as_stream.rs
+++ b/examples/fetch_as_stream.rs
@@ -3,7 +3,7 @@
 //! This example makes an HTTP request using `fetch()` from `web-sys`,
 //! and then consumes the response body as a Rust `Stream`.
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{console, window, Response};

--- a/src/readable/into_async_read.rs
+++ b/src/readable/into_async_read.rs
@@ -1,9 +1,9 @@
 use core::pin::Pin;
+use core::task::{Context, Poll};
 
-use futures::future::FutureExt;
-use futures::io::{AsyncRead, Error};
-use futures::ready;
-use futures::task::{Context, Poll};
+use futures_util::FutureExt;
+use futures_util::io::{AsyncRead, Error};
+use futures_util::ready;
 use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;

--- a/src/readable/into_async_read.rs
+++ b/src/readable/into_async_read.rs
@@ -1,9 +1,9 @@
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
-use futures_util::FutureExt;
 use futures_util::io::{AsyncRead, Error};
 use futures_util::ready;
+use futures_util::FutureExt;
 use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;

--- a/src/readable/into_stream.rs
+++ b/src/readable/into_stream.rs
@@ -1,9 +1,9 @@
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
-use futures_util::FutureExt;
 use futures_util::ready;
 use futures_util::stream::{FusedStream, Stream};
+use futures_util::FutureExt;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 

--- a/src/readable/into_stream.rs
+++ b/src/readable/into_stream.rs
@@ -1,9 +1,9 @@
 use core::pin::Pin;
+use core::task::{Context, Poll};
 
-use futures::future::FutureExt;
-use futures::ready;
-use futures::stream::{FusedStream, Stream};
-use futures::task::{Context, Poll};
+use futures_util::FutureExt;
+use futures_util::ready;
+use futures_util::stream::{FusedStream, Stream};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 

--- a/src/readable/into_underlying_byte_source.rs
+++ b/src/readable/into_underlying_byte_source.rs
@@ -2,8 +2,8 @@ use std::cell::RefCell;
 use std::pin::Pin;
 use std::rc::Rc;
 
-use futures::future::{abortable, AbortHandle, TryFutureExt};
-use futures::io::{AsyncRead, AsyncReadExt};
+use futures_util::future::{abortable, AbortHandle, TryFutureExt};
+use futures_util::io::{AsyncRead, AsyncReadExt};
 use js_sys::{Error as JsError, Promise, Uint8Array};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;

--- a/src/readable/into_underlying_source.rs
+++ b/src/readable/into_underlying_source.rs
@@ -2,8 +2,8 @@ use std::cell::RefCell;
 use std::pin::Pin;
 use std::rc::Rc;
 
-use futures::future::{abortable, AbortHandle, TryFutureExt};
-use futures::stream::{Stream, TryStreamExt};
+use futures_util::future::{abortable, AbortHandle, TryFutureExt};
+use futures_util::stream::{Stream, TryStreamExt};
 use js_sys::Promise;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;

--- a/src/readable/mod.rs
+++ b/src/readable/mod.rs
@@ -1,7 +1,7 @@
 //! Bindings and conversions for
 //! [readable streams](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
-use futures::io::AsyncRead;
-use futures::stream::Stream;
+use futures_util::io::AsyncRead;
+use futures_util::Stream;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 

--- a/src/writable/into_async_write.rs
+++ b/src/writable/into_async_write.rs
@@ -1,8 +1,8 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures_util::ready;
 use futures_util::io::AsyncWrite;
+use futures_util::ready;
 use futures_util::sink::SinkExt;
 use js_sys::Uint8Array;
 use wasm_bindgen::JsValue;

--- a/src/writable/into_async_write.rs
+++ b/src/writable/into_async_write.rs
@@ -1,9 +1,9 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::io::AsyncWrite;
-use futures::ready;
-use futures::sink::SinkExt;
+use futures_util::ready;
+use futures_util::io::AsyncWrite;
+use futures_util::sink::SinkExt;
 use js_sys::Uint8Array;
 use wasm_bindgen::JsValue;
 

--- a/src/writable/into_sink.rs
+++ b/src/writable/into_sink.rs
@@ -1,8 +1,8 @@
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
-use futures_util::{FutureExt, ready};
 use futures_util::Sink;
+use futures_util::{ready, FutureExt};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 

--- a/src/writable/into_sink.rs
+++ b/src/writable/into_sink.rs
@@ -1,9 +1,8 @@
 use core::pin::Pin;
+use core::task::{Context, Poll};
 
-use futures::future::FutureExt;
-use futures::ready;
-use futures::sink::Sink;
-use futures::task::{Context, Poll};
+use futures_util::{FutureExt, ready};
+use futures_util::Sink;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 

--- a/src/writable/into_underlying_sink.rs
+++ b/src/writable/into_underlying_sink.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::pin::Pin;
 use std::rc::Rc;
 
-use futures::sink::{Sink, SinkExt};
+use futures_util::{Sink, SinkExt};
 use js_sys::Promise;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;

--- a/src/writable/mod.rs
+++ b/src/writable/mod.rs
@@ -1,7 +1,7 @@
 //! Bindings and conversions for
 //! [writable streams](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
 
-use futures::Sink;
+use futures_util::Sink;
 use wasm_bindgen::prelude::*;
 
 pub use default_writer::WritableStreamDefaultWriter;

--- a/tests/tests/pipe.rs
+++ b/tests/tests/pipe.rs
@@ -1,6 +1,6 @@
-use futures::channel::mpsc;
-use futures::stream::iter;
-use futures::{SinkExt, StreamExt};
+use futures_channel::mpsc;
+use futures_util::stream::iter;
+use futures_util::{SinkExt, StreamExt};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 

--- a/tests/tests/pipe.rs
+++ b/tests/tests/pipe.rs
@@ -1,4 +1,4 @@
-use futures_channel::mpsc;
+use futures::channel::mpsc;
 use futures_util::stream::iter;
 use futures_util::{SinkExt, StreamExt};
 use wasm_bindgen::prelude::*;

--- a/tests/tests/readable_byte_stream.rs
+++ b/tests/tests/readable_byte_stream.rs
@@ -1,8 +1,8 @@
 use std::pin::Pin;
+use std::task::Poll;
 
-use futures::io::AsyncReadExt;
-use futures::task::Poll;
-use futures::{poll, FutureExt};
+use futures_util::AsyncReadExt;
+use futures_util::{poll, FutureExt};
 use js_sys::Uint8Array;
 use wasm_bindgen_test::*;
 

--- a/tests/tests/readable_stream.rs
+++ b/tests/tests/readable_stream.rs
@@ -1,9 +1,8 @@
 use std::pin::Pin;
+use std::task::Poll;
 
-use futures::io::AsyncReadExt;
-use futures::stream::{iter, pending, StreamExt, TryStreamExt};
-use futures::task::Poll;
-use futures::{poll, FutureExt};
+use futures_util::stream::{iter, pending, StreamExt, TryStreamExt};
+use futures_util::{AsyncReadExt, FutureExt, poll};
 use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;

--- a/tests/tests/readable_stream.rs
+++ b/tests/tests/readable_stream.rs
@@ -2,7 +2,7 @@ use std::pin::Pin;
 use std::task::Poll;
 
 use futures_util::stream::{iter, pending, StreamExt, TryStreamExt};
-use futures_util::{AsyncReadExt, FutureExt, poll};
+use futures_util::{poll, AsyncReadExt, FutureExt};
 use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;

--- a/tests/tests/transform_stream.rs
+++ b/tests/tests/transform_stream.rs
@@ -1,4 +1,4 @@
-use futures::future::join;
+use futures_util::future::join;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 

--- a/tests/tests/writable_stream.rs
+++ b/tests/tests/writable_stream.rs
@@ -1,8 +1,8 @@
 use std::pin::Pin;
 
-use futures::channel::*;
-use futures::stream::iter;
-use futures::{AsyncReadExt, AsyncWriteExt, SinkExt, StreamExt};
+use futures_channel::*;
+use futures_util::stream::iter;
+use futures_util::{AsyncReadExt, AsyncWriteExt, SinkExt, StreamExt};
 use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -259,12 +259,12 @@ async fn test_writable_stream_from_async_write() {
     let sink = async_write
         .into_sink()
         .with(
-            |js_value: JsValue| -> futures::future::Ready<std::io::Result<Vec<u8>>> {
-                futures::future::ready(Ok(js_value.dyn_into::<Uint8Array>().unwrap().to_vec()))
+            |js_value: JsValue| -> std::future::Ready<std::io::Result<Vec<u8>>> {
+                std::future::ready(Ok(js_value.dyn_into::<Uint8Array>().unwrap().to_vec()))
             },
         )
         .sink_map_err(|_| JsValue::undefined());
-    let mut writable = WritableStream::from_sink(Box::new(sink));
+    let mut writable = WritableStream::from_sink(sink);
     assert!(!writable.is_locked());
 
     let mut writer = writable.get_writer();

--- a/tests/tests/writable_stream.rs
+++ b/tests/tests/writable_stream.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-use futures_channel::*;
+use futures_channel::mpsc;
 use futures_util::stream::iter;
 use futures_util::{AsyncReadExt, AsyncWriteExt, SinkExt, StreamExt};
 use js_sys::Uint8Array;

--- a/tests/tests/writable_stream.rs
+++ b/tests/tests/writable_stream.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-use futures_channel::mpsc;
+use futures::channel::mpsc;
 use futures_util::stream::iter;
 use futures_util::{AsyncReadExt, AsyncWriteExt, SinkExt, StreamExt};
 use js_sys::Uint8Array;

--- a/tests/util/byte_channel.rs
+++ b/tests/util/byte_channel.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use std::pin::Pin;
 use std::task::{Context, Poll, Waker};
 
-use futures::{AsyncRead, AsyncWrite};
+use futures_util::{AsyncRead, AsyncWrite};
 
 #[derive(Debug, Default)]
 pub struct ByteChannel {
@@ -67,8 +67,8 @@ impl AsyncWrite for ByteChannel {
 
 #[cfg(test)]
 mod tests {
-    use futures::future::join;
-    use futures::io::{AsyncReadExt, AsyncWriteExt};
+    use futures_util::future::join;
+    use futures_util::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
 

--- a/tests/util/drop_observer.rs
+++ b/tests/util/drop_observer.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 
-use futures::{Sink, Stream};
+use futures_util::{Sink, Stream};
 use pin_project::{pin_project, pinned_drop};
 
 #[pin_project(PinnedDrop)]


### PR DESCRIPTION
This PR attempts to improve compilation times by minimizing our dependency on the heavy `futures` crate, which compiles the `futures-executor` crate by default. In my fork, the same GitHub Actions workflows dropped by ~20 seconds. This is great!

I did face some _really_ strange issues that required temporary workarounds with the `devDependencies`. But as far as the user is concerned, they should not be affected by these changes. More on that in a separate review comment.

Besides that, everything should be alright! 👍