### PR TITLE
Support usage in web workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * Added support for web workers, by removing usage of [JavaScript snippets](https://rustwasm.github.io/docs/wasm-bindgen/reference/js-snippets.html). ([#13](https://github.com/MattiasBuelens/wasm-streams/issues/13), [#14](https://github.com/MattiasBuelens/wasm-streams/pull/14))
 * ⚠ **Breaking change:** This removes a workaround for [Chromium bug #1187774](https://crbug.com/1187774) that was previously needed for `ReadableStream::from_async_read`. This bug was fixed upstream in March 2021 with Chrome 91. ([#14](https://github.com/MattiasBuelens/wasm-streams/pull/14))
 * Updated documentation of `ReadableStream(Default|BYOB)Reader::release_lock()` around the expected behavior when there are pending read requests.
-  See the corresponding [Streams specification change](https://github.com/whatwg/streams/commit/d5f92d9f17306d31ba6b27424d23d58e89bf64a5) for details. 
+  See the corresponding [Streams specification change](https://github.com/whatwg/streams/commit/d5f92d9f17306d31ba6b27424d23d58e89bf64a5) for details.
+  ([#15](https://github.com/MattiasBuelens/wasm-streams/pull/15)) 
 
 ## v0.2.3 (2022-05-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Added support for web workers, by removing usage of [JavaScript snippets](https://rustwasm.github.io/docs/wasm-bindgen/reference/js-snippets.html). ([#13](https://github.com/MattiasBuelens/wasm-streams/issues/13), [#14](https://github.com/MattiasBuelens/wasm-streams/pull/14))
+* ⚠ **Breaking change:** This removes a workaround for [Chromium bug #1187774](https://crbug.com/1187774) that was previously needed for `ReadableStream::from_async_read`. This bug was fixed upstream in March 2021 with Chrome 91. ([#14](https://github.com/MattiasBuelens/wasm-streams/pull/14))
 * Updated documentation of `ReadableStream(Default|BYOB)Reader::release_lock()` around the expected behavior when there are pending read requests.
   See the corresponding [Streams specification change](https://github.com/whatwg/streams/commit/d5f92d9f17306d31ba6b27424d23d58e89bf64a5) for details. 
 

--- a/src/readable/into_underlying_byte_source.rs
+++ b/src/readable/into_underlying_byte_source.rs
@@ -31,24 +31,12 @@ impl IntoUnderlyingByteSource {
     }
 }
 
-#[wasm_bindgen(inline_js = "export function bytes_literal() { return \"bytes\"; }")]
-extern "C" {
-    fn bytes_literal() -> JsValue;
-}
-
 #[allow(clippy::await_holding_refcell_ref)]
 #[wasm_bindgen]
 impl IntoUnderlyingByteSource {
-    // Chromium has a bug where it only recognizes `new ReadableStream({ type: "bytes" })`,
-    // not `new ReadableStream({ type: "by" + "tes" })` or any other non-literal string
-    // that equals "bytes". Therefore, we cannot return a Rust `String` here, since
-    // that needs to be converted to a JavaScript string at runtime.
-    // Instead, we call a function that returns the desired string literal as a `JsValue`
-    // and pass that value around. It looks silly, but it works.
-    // See https://crbug.com/1187774
     #[wasm_bindgen(getter, js_name = type)]
-    pub fn type_(&self) -> JsValue {
-        bytes_literal()
+    pub fn type_(&self) -> String {
+        "bytes".into()
     }
 
     #[wasm_bindgen(getter, js_name = autoAllocateChunkSize)]


### PR DESCRIPTION
This removes all usages of [JavaScript snippets](https://rustwasm.github.io/docs/wasm-bindgen/reference/js-snippets.html) in the code, so the crate can also be used in web workers (where such snippets aren't available).

This is done by reverting 67bb2a413bc3ba2ff8de0a4a18fbb0e3ac59899b (Work around Chromium bug with `{ type: "bytes" }`). Since [Chromium bug #1187774](https://crbug.com/1187774) was fixed upstream a while ago, there's no need to keep this workaround in the code.

Fixes #13.