### PR TITLE
Stop calling byobRequest.respond(0) on cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Stop calling `byobRequest.respond(0)` on cancel ([#16](https://github.com/MattiasBuelens/wasm-streams/pull/16))
+
 ## v0.3.0 (2022-10-16)
 
 * Added support for web workers, by removing usage of [JavaScript snippets](https://rustwasm.github.io/docs/wasm-bindgen/reference/js-snippets.html). ([#13](https://github.com/MattiasBuelens/wasm-streams/issues/13), [#14](https://github.com/MattiasBuelens/wasm-streams/pull/14))

--- a/src/readable/into_underlying_byte_source.rs
+++ b/src/readable/into_underlying_byte_source.rs
@@ -113,8 +113,8 @@ impl Inner {
             Ok(0) => {
                 // The stream has closed, drop it.
                 self.discard();
-                controller.close();
-                request.respond(0);
+                controller.close()?;
+                request.respond(0)?;
             }
             Ok(bytes_read) => {
                 // Copy read bytes from buffer to BYOB request view
@@ -127,7 +127,7 @@ impl Inner {
                 );
                 dest.copy_from(&self.buffer[0..bytes_read]);
                 // Respond to BYOB request
-                request.respond(bytes_read_u32);
+                request.respond(bytes_read_u32)?;
             }
             Err(err) => {
                 // The stream encountered an error, drop it.

--- a/src/readable/into_underlying_byte_source.rs
+++ b/src/readable/into_underlying_byte_source.rs
@@ -78,10 +78,6 @@ impl Drop for IntoUnderlyingByteSource {
         if let Some(handle) = self.pull_handle.take() {
             handle.abort();
         }
-        // Close the pending BYOB request, if any. This is necessary for cancellation.
-        if let Some(request) = self.controller.take().and_then(|c| c.byob_request()) {
-            request.respond(0);
-        }
     }
 }
 
@@ -106,9 +102,9 @@ impl Inner {
         // after the stream has closed or encountered an error.
         let async_read = self.async_read.as_mut().unwrap_throw();
         // We set autoAllocateChunkSize, so there should always be a BYOB request.
-        let mut request = ByobRequestGuard::new(controller.byob_request().unwrap_throw());
+        let request = controller.byob_request().unwrap_throw();
         // Resize the buffer to fit the BYOB request.
-        let request_view = request.view();
+        let request_view = request.view().unwrap_throw();
         let request_len = clamp_to_usize(request_view.byte_length());
         if self.buffer.len() < request_len {
             self.buffer.resize(request_len, 0);
@@ -146,31 +142,5 @@ impl Inner {
     fn discard(&mut self) {
         self.async_read = None;
         self.buffer = Vec::new();
-    }
-}
-
-#[derive(Debug)]
-struct ByobRequestGuard(Option<sys::ReadableStreamBYOBRequest>);
-
-impl ByobRequestGuard {
-    fn new(request: sys::ReadableStreamBYOBRequest) -> Self {
-        Self(Some(request))
-    }
-
-    fn view(&mut self) -> sys::ArrayBufferView {
-        self.0.as_mut().unwrap_throw().view().unwrap_throw()
-    }
-
-    fn respond(mut self, bytes_read: u32) {
-        self.0.take().unwrap_throw().respond(bytes_read);
-    }
-}
-
-impl Drop for ByobRequestGuard {
-    fn drop(&mut self) {
-        // Close the BYOB request, if still pending. This is necessary for cancellation.
-        if let Some(request) = self.0.take() {
-            request.respond(0);
-        }
     }
 }

--- a/src/readable/into_underlying_source.rs
+++ b/src/readable/into_underlying_source.rs
@@ -82,11 +82,11 @@ impl Inner {
         // after the stream has closed or encountered an error.
         let stream = self.stream.as_mut().unwrap_throw();
         match stream.try_next().await {
-            Ok(Some(chunk)) => controller.enqueue(&chunk),
+            Ok(Some(chunk)) => controller.enqueue(&chunk)?,
             Ok(None) => {
                 // The stream has closed, drop it.
                 self.stream = None;
-                controller.close();
+                controller.close()?;
             }
             Err(err) => {
                 // The stream encountered an error, drop it.

--- a/src/readable/sys.rs
+++ b/src/readable/sys.rs
@@ -72,11 +72,11 @@ extern "C" {
     #[wasm_bindgen(method, getter, js_name = desiredSize)]
     pub fn desired_size(this: &ReadableStreamDefaultController) -> Option<f64>;
 
-    #[wasm_bindgen(method, js_name = close)]
-    pub fn close(this: &ReadableStreamDefaultController);
+    #[wasm_bindgen(method, catch, js_name = close)]
+    pub fn close(this: &ReadableStreamDefaultController) -> Result<(), JsValue>;
 
-    #[wasm_bindgen(method, js_name = enqueue)]
-    pub fn enqueue(this: &ReadableStreamDefaultController, chunk: &JsValue);
+    #[wasm_bindgen(method, catch, js_name = enqueue)]
+    pub fn enqueue(this: &ReadableStreamDefaultController, chunk: &JsValue) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, js_name = error)]
     pub fn error(this: &ReadableStreamDefaultController, error: &JsValue);
@@ -94,11 +94,14 @@ extern "C" {
     #[wasm_bindgen(method, getter, js_name = desiredSize)]
     pub fn desired_size(this: &ReadableByteStreamController) -> Option<f64>;
 
-    #[wasm_bindgen(method, js_name = close)]
-    pub fn close(this: &ReadableByteStreamController);
+    #[wasm_bindgen(method, catch, js_name = close)]
+    pub fn close(this: &ReadableByteStreamController) -> Result<(), JsValue>;
 
-    #[wasm_bindgen(method, js_name = enqueue)]
-    pub fn enqueue(this: &ReadableByteStreamController, chunk: &ArrayBufferView);
+    #[wasm_bindgen(method, catch, js_name = enqueue)]
+    pub fn enqueue(
+        this: &ReadableByteStreamController,
+        chunk: &ArrayBufferView,
+    ) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, js_name = error)]
     pub fn error(this: &ReadableByteStreamController, error: &JsValue);
@@ -113,11 +116,14 @@ extern "C" {
     #[wasm_bindgen(method, getter, js_name = view)]
     pub fn view(this: &ReadableStreamBYOBRequest) -> Option<ArrayBufferView>;
 
-    #[wasm_bindgen(method, js_name = respond)]
-    pub fn respond(this: &ReadableStreamBYOBRequest, bytes_written: u32);
+    #[wasm_bindgen(method, catch, js_name = respond)]
+    pub fn respond(this: &ReadableStreamBYOBRequest, bytes_written: u32) -> Result<(), JsValue>;
 
-    #[wasm_bindgen(method, js_name = respondWithNewView)]
-    pub fn respond_with_new_view(this: &ReadableStreamBYOBRequest, view: &ArrayBufferView);
+    #[wasm_bindgen(method, catch, js_name = respondWithNewView)]
+    pub fn respond_with_new_view(
+        this: &ReadableStreamBYOBRequest,
+        view: &ArrayBufferView,
+    ) -> Result<(), JsValue>;
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
As of https://github.com/whatwg/streams/pull/1129, it's no longer necessary for an underlying byte source to call `byobRequest.respond(0)` inside its `cancel()` method. The stream takes care of invalidating the BYOB request immediately on cancel.

At the moment, readable byte streams are implemented in Chrome and Firefox, and both have also implemented this spec change (see [wpt.fyi](https://wpt.fyi/results/streams/readable-byte-streams/general.any.html?label=experimental&label=master&aligned)). As such, I think it's safe for `wasm-streams` to rely on the browser to do the right thing. 🙂