### PR TITLE
Fix dropped closure error in `Drop` impls of `IntoStream` and `IntoAsyncRead`

### DIFF
--- a/src/readable/into_async_read.rs
+++ b/src/readable/into_async_read.rs
@@ -137,7 +137,9 @@ impl<'reader> Drop for IntoAsyncRead<'reader> {
     fn drop(&mut self) {
         if self.cancel_on_drop {
             if let Some(reader) = self.reader.take() {
-                let _ = reader.as_raw().cancel().catch(&Closure::once(|_| {}));
+                let on_rejected = Closure::once(|_| {});
+                let _ = reader.as_raw().cancel().catch(&on_rejected);
+                on_rejected.forget();
             }
         }
     }

--- a/src/readable/into_stream.rs
+++ b/src/readable/into_stream.rs
@@ -109,7 +109,9 @@ impl<'reader> Drop for IntoStream<'reader> {
     fn drop(&mut self) {
         if self.cancel_on_drop {
             if let Some(reader) = self.reader.take() {
-                let _ = reader.as_raw().cancel().catch(&Closure::once(|_| {}));
+                let on_rejected = Closure::once(|_| {});
+                let _ = reader.as_raw().cancel().catch(&on_rejected);
+                on_rejected.forget();
             }
         }
     }


### PR DESCRIPTION
Closes #24.