### PR TITLE
fix: implement UnwindSafe/RefUnwindSafe for wasm-bindgen exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: cargo test --target=x86_64-unknown-linux-gnu
 
       - name: Install wasm-pack
-        run: curl https://drager.github.io/wasm-pack/installer/init.sh -sSf | bash
+        run: curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | bash
 
       - name: Test on Node
         run: wasm-pack test --node -- ${{ matrix.unstable-flags }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ features = [
 wasm-bindgen-test = "0.3.58"
 tokio = { version = "^1", features = ["macros", "rt"] }
 pin-project = "^1"
-gloo-timers = { version = "^0.3.0", features = ["futures"] }
+gloo-timers = { version = "^0.4.0", features = ["futures"] }
 
 [dev-dependencies.web-sys]
 version = "^0.3.85"
@@ -70,3 +70,7 @@ features = [
 [package.metadata.docs.rs]
 # https://blog.rust-lang.org/2020/03/15/docs-rs-opt-into-fewer-targets.html
 targets = ["x86_64-unknown-linux-gnu"]
+
+# Pending gloo PR https://github.com/rustwasm/gloo/pull/562 with unwind safety
+[patch.crates-io]
+gloo-timers = { git = "https://github.com/guybedford/gloo", branch = "fix-gloo-timers-unwind-safety" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ features = [
 wasm-bindgen-test = "0.3.58"
 tokio = { version = "^1", features = ["macros", "rt"] }
 pin-project = "^1"
-gloo-timers = { version = "^0.4.0", features = ["futures"] }
+gloo-timers = { version = "^0.3.0", features = ["futures"] }
 
 [dev-dependencies.web-sys]
 version = "^0.3.85"
@@ -70,7 +70,3 @@ features = [
 [package.metadata.docs.rs]
 # https://blog.rust-lang.org/2020/03/15/docs-rs-opt-into-fewer-targets.html
 targets = ["x86_64-unknown-linux-gnu"]
-
-# Pending gloo PR https://github.com/rustwasm/gloo/pull/562 with unwind safety
-[patch.crates-io]
-gloo-timers = { git = "https://github.com/guybedford/gloo", branch = "fix-gloo-timers-unwind-safety" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ features = [
 wasm-bindgen-test = "0.3.58"
 tokio = { version = "^1", features = ["macros", "rt"] }
 pin-project = "^1"
-gloo-timers = { version = "^0.3.0", features = ["futures"] }
 
 [dev-dependencies.web-sys]
 version = "^0.3.85"

--- a/src/readable/into_underlying_byte_source.rs
+++ b/src/readable/into_underlying_byte_source.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::panic::AssertUnwindSafe;
+use std::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::rc::Rc;
 
@@ -20,6 +20,16 @@ pub(crate) struct IntoUnderlyingByteSource {
     controller: Option<sys::ReadableByteStreamController>,
     pull_handle: Option<AbortHandle>,
 }
+
+// SAFETY: `Inner` holds an `Option<Pin<Box<dyn AsyncRead>>>` and uses the
+// take-and-replace pattern across every fallible await point in `Inner::pull`.
+// On panic, the inner async_read is already taken out of the `Option`, leaving
+// the cell in a clean `None` state. The `Rc<RefCell<Inner>>` interior mutability
+// therefore cannot expose torn invariants to a subsequent call after a caught
+// panic, satisfying the logical unwind-safety contract enforced by
+// `#[wasm_bindgen]` exports under `panic = "unwind"`.
+impl UnwindSafe for IntoUnderlyingByteSource {}
+impl RefUnwindSafe for IntoUnderlyingByteSource {}
 
 impl IntoUnderlyingByteSource {
     pub fn new(async_read: Box<dyn AsyncRead>, default_buffer_len: usize) -> Self {

--- a/src/readable/into_underlying_source.rs
+++ b/src/readable/into_underlying_source.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::panic::AssertUnwindSafe;
+use std::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::rc::Rc;
 
@@ -18,6 +18,15 @@ pub(crate) struct IntoUnderlyingSource {
     inner: Rc<RefCell<Inner>>,
     pull_handle: Option<AbortHandle>,
 }
+
+// SAFETY: `Inner` holds an `Option<Pin<Box<JsValueStream>>>` and uses the
+// take-and-replace pattern around every fallible await in `Inner::pull`. On
+// panic, the stream is already taken out of the `Option`, leaving the cell in
+// a clean `None` state. Subsequent calls fail cleanly via `unwrap_throw`
+// rather than observing a torn intermediate state, which upholds the logical
+// unwind-safety contract `#[wasm_bindgen]` enforces for exported types.
+impl UnwindSafe for IntoUnderlyingSource {}
+impl RefUnwindSafe for IntoUnderlyingSource {}
 
 impl IntoUnderlyingSource {
     pub fn new(stream: Box<JsValueStream>) -> Self {

--- a/src/writable/into_underlying_sink.rs
+++ b/src/writable/into_underlying_sink.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::panic::AssertUnwindSafe;
+use std::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::rc::Rc;
 
@@ -12,6 +12,16 @@ use wasm_bindgen_futures::future_to_promise;
 pub(crate) struct IntoUnderlyingSink {
     inner: Rc<RefCell<Inner>>,
 }
+
+// SAFETY: `Inner` holds an `Option<Pin<Box<dyn Sink<...>>>>` and uses the
+// take-and-replace pattern around every fallible await in `Inner::write` /
+// `Inner::close` / `Inner::abort`. On panic the sink is already taken out of
+// the `Option`, leaving the cell in a clean `None` state. The
+// `Rc<RefCell<Inner>>` interior mutability therefore cannot expose torn
+// invariants after a caught panic, upholding the logical unwind-safety
+// contract enforced by `#[wasm_bindgen]` exports under `panic = "unwind"`.
+impl UnwindSafe for IntoUnderlyingSink {}
+impl RefUnwindSafe for IntoUnderlyingSink {}
 
 impl IntoUnderlyingSink {
     pub fn new(sink: Box<dyn Sink<JsValue, Error = JsValue>>) -> Self {

--- a/tests/tests/fetch_as_stream.rs
+++ b/tests/tests/fetch_as_stream.rs
@@ -10,7 +10,7 @@ use web_sys::{Response, Window};
 #[wasm_bindgen_test]
 async fn test_fetch_as_stream() {
     // Make a fetch request
-    let url = "https://drager.github.io/wasm-pack/public/img/wasm-ferris.png";
+    let url = "https://wasm-bindgen.github.io/wasm-pack/public/img/wasm-ferris.png";
     let window = global().unchecked_into::<Window>(); // hack to also support Node.js
     let resp_value = JsFuture::from(window.fetch_with_str(url))
         .await

--- a/tests/tests/readable_byte_stream.rs
+++ b/tests/tests/readable_byte_stream.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use futures_util::AsyncReadExt;
 use futures_util::{FutureExt, poll};
-use gloo_timers::future::sleep;
 use js_sys::Uint8Array;
 use wasm_bindgen_test::*;
 

--- a/tests/tests/readable_stream.rs
+++ b/tests/tests/readable_stream.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use futures_util::stream::{StreamExt, TryStreamExt, iter, pending};
 use futures_util::{AsyncReadExt, FutureExt, poll};
-use gloo_timers::future::sleep;
 use js_sys::Uint8Array;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -2,6 +2,7 @@ pub use byte_channel::ByteChannel;
 pub use drop_observer::observe_drop;
 pub use failing_sink::FailingSink;
 pub use simple_channel::SimpleChannel;
+pub use sleep::sleep;
 pub use unhandled_error_guard::UnhandledErrorGuard;
 
 pub mod byte_channel;
@@ -10,4 +11,5 @@ pub mod drop_observer;
 pub mod failing_sink;
 pub mod panicking;
 pub mod simple_channel;
+pub mod sleep;
 pub mod unhandled_error_guard;

--- a/tests/util/sleep.rs
+++ b/tests/util/sleep.rs
@@ -1,0 +1,24 @@
+use std::time::Duration;
+
+use js_sys::Promise;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = setTimeout)]
+    fn set_timeout(handler: &::js_sys::Function, timeout: i32) -> JsValue;
+}
+
+/// Resolves after the given duration using the global `setTimeout`.
+///
+/// Avoids depending on `gloo-timers`, which currently fails to compile against
+/// recent `wasm-bindgen` versions when `panic=unwind` is enabled (see
+/// rustwasm/gloo#562).
+pub async fn sleep(duration: Duration) {
+    let millis = duration.as_millis() as i32;
+    let promise = Promise::new(&mut |resolve, _reject| {
+        set_timeout(&resolve, millis);
+    });
+    let _ = JsFuture::from(promise).await;
+}

--- a/tests/util/unhandled_error_guard.rs
+++ b/tests/util/unhandled_error_guard.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::panic::AssertUnwindSafe;
 use std::rc::Rc;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
@@ -16,12 +17,15 @@ impl UnhandledErrorGuard {
         // Add a listener that collects any errors
         let errors = Rc::new(RefCell::new(vec![]));
         let listener = {
-            let errors = errors.clone();
+            let errors = AssertUnwindSafe(errors.clone());
             Closure::<dyn FnMut(_)>::new(move |event: JsValue| {
-                if let Some(event) = event.dyn_ref::<ErrorEvent>() {
-                    errors.borrow_mut().push(event.error());
-                } else if let Some(event) = event.dyn_ref::<PromiseRejectionEvent>() {
-                    errors.borrow_mut().push(event.reason());
+                let err = if let Some(event) = event.dyn_ref::<ErrorEvent>() {
+                    Some(event.error())
+                } else {
+                    event.dyn_ref::<PromiseRejectionEvent>().map(|e| e.reason())
+                };
+                if let Some(err) = err {
+                    errors.borrow_mut().push(err);
                 }
             })
         };


### PR DESCRIPTION
Upcoming versions of wasm-bindgen will emit a type-level `RefUnwindSafe` assertion on every `#[wasm_bindgen]` exported method under `panic = "unwind"`, because the method body is invoked inside a `catch_unwind` boundary. `IntoUnderlyingSource`, `IntoUnderlyingByteSource` and `IntoUnderlyingSink` all hold `Rc<RefCell<Inner>>`, so the assertion fails and downstream crates that depend on `wasm-streams` (e.g. `workers-rs`) fail to build with `panic=unwind`.

The take-and-replace pattern already in place around every fallible await in `Inner::pull` / `Inner::write` / `Inner::close` / `Inner::abort` means the inner `Option<...>` is always `None` whenever a panic propagates, so no torn intermediate state can leak through the `RefCell` to a subsequent call. That is exactly the property the `RefUnwindSafe` contract advertises, so it is sound to add explicit impls for the three exported types:

```rs
impl UnwindSafe for IntoUnderlyingSource {}
impl RefUnwindSafe for IntoUnderlyingSource {}
```

(and likewise for `IntoUnderlyingByteSource` and `IntoUnderlyingSink`).

The impls are inert on toolchains whose wasm-bindgen does not yet emit the assertion, so this is a purely additive change with no behavioural impact on the existing `panic=unwind` test matrix. The existing `tests/tests/panic_unwind.rs` continues to cover the actual unwind behaviour.