### PR TITLE
Update minimum supported Rust version to 1.88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           - toolchain: nightly-2026-01-28
             rust-flags: "-Cpanic=unwind"
             unstable-flags: "-Zbuild-std"
+          # Minimum supported Rust version (see Cargo.toml)
+          - toolchain: 1.88.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "wasm-streams"
 version = "0.5.0"
 authors = ["Mattias Buelens <mattias@buelens.com>"]
 edition = "2024"
+# See https://crates.io/crates/cargo-msrv
+rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/MattiasBuelens/wasm-streams/"


### PR DESCRIPTION
I used [cargo msrv find](https://gribnau.dev/cargo-msrv/commands/find.html) to find the minimum supported Rust version. As expected, it's the one where `if let` chains became stable, [see release notes](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/).

We now also test this version on CI. 😉