### PR TITLE
Test with panic=unwind on latest nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,8 @@ jobs:
         include:
           - toolchain: stable
           - toolchain: nightly
-          # Recent Rust nightlies with LLVM 22 are temporarily broken with panic=unwind.
-          # See https://github.com/wasm-bindgen/wasm-bindgen/issues/4929
-          - toolchain: nightly-2026-01-28
+          # Test with panic=unwind
+          - toolchain: nightly
             rust-flags: "-Cpanic=unwind"
             unstable-flags: "-Zbuild-std"
           # Minimum supported Rust version (see Cargo.toml)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
           components: rust-src
           rustflags: ${{ matrix.rust-flags }}
 
-      - name: Install Node 23
+      - name: Install Node 24
         uses: actions/setup-node@v6
         with:
-          node-version: 23
+          node-version: 24
 
       - name: Run cargo check
         run: cargo check --target wasm32-unknown-unknown ${{ matrix.unstable-flags }}


### PR DESCRIPTION
https://github.com/wasm-bindgen/wasm-bindgen/issues/4929 should be fixed now, I think?