### PR TITLE
Use imported closures instead of exported classes for underlying sources and sinks

### DIFF
--- a/src/readable/into_underlying_byte_source.rs
+++ b/src/readable/into_underlying_byte_source.rs
@@ -1,11 +1,12 @@
 use std::cell::RefCell;
-use std::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
+use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::rc::Rc;
 
 use futures_util::future::{AbortHandle, TryFutureExt, abortable};
 use futures_util::io::{AsyncRead, AsyncReadExt};
 use js_sys::{Error as JsError, Promise, Uint8Array};
+use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
@@ -13,23 +14,12 @@ use crate::util::{checked_cast_to_u32, clamp_to_usize};
 
 use super::sys;
 
-#[wasm_bindgen]
 pub(crate) struct IntoUnderlyingByteSource {
     inner: Rc<RefCell<Inner>>,
     default_buffer_len: usize,
     controller: Option<sys::ReadableByteStreamController>,
     pull_handle: Option<AbortHandle>,
 }
-
-// SAFETY: `Inner` holds an `Option<Pin<Box<dyn AsyncRead>>>` and uses the
-// take-and-replace pattern across every fallible await point in `Inner::pull`.
-// On panic, the inner async_read is already taken out of the `Option`, leaving
-// the cell in a clean `None` state. The `Rc<RefCell<Inner>>` interior mutability
-// therefore cannot expose torn invariants to a subsequent call after a caught
-// panic, satisfying the logical unwind-safety contract enforced by
-// `#[wasm_bindgen]` exports under `panic = "unwind"`.
-impl UnwindSafe for IntoUnderlyingByteSource {}
-impl RefUnwindSafe for IntoUnderlyingByteSource {}
 
 impl IntoUnderlyingByteSource {
     pub fn new(async_read: Box<dyn AsyncRead>, default_buffer_len: usize) -> Self {
@@ -40,26 +30,62 @@ impl IntoUnderlyingByteSource {
             pull_handle: None,
         }
     }
-}
 
-#[allow(clippy::await_holding_refcell_ref)]
-#[wasm_bindgen]
-impl IntoUnderlyingByteSource {
-    #[wasm_bindgen(getter, js_name = type)]
-    pub fn type_(&self) -> sys::ReadableStreamType {
-        sys::ReadableStreamType::Bytes
+    /// Converts into a raw [`UnderlyingSource`](sys::UnderlyingSource) object,
+    /// with `start`, `pull` and `cancel` backed by imported closures.
+    /// The closures (and thus the source) live as long as the JS object,
+    /// and are deallocated through GC finalization.
+    pub fn into_raw(self) -> sys::UnderlyingSource {
+        let raw = sys::UnderlyingSource::new();
+        raw.set_type(sys::ReadableStreamType::Bytes);
+        raw.set_auto_allocate_chunk_size(checked_cast_to_u32(self.default_buffer_len) as f64);
+        let source = Rc::new(RefCell::new(Some(self)));
+
+        let start = {
+            let source = source.clone();
+            Closure::<dyn FnMut(sys::ReadableByteStreamController)>::new(move |controller| {
+                source
+                    .try_borrow_mut()
+                    .unwrap_throw()
+                    .as_mut()
+                    .unwrap_throw()
+                    .start(controller)
+            })
+        };
+        raw.set_start(start.into_js_value().unchecked_ref());
+
+        let pull = {
+            let source = source.clone();
+            Closure::<dyn FnMut(sys::ReadableByteStreamController) -> Promise>::new(
+                move |controller| {
+                    // This mutable borrow can never panic, since the ReadableStream
+                    // always queues each operation on the underlying source.
+                    source
+                        .try_borrow_mut()
+                        .unwrap_throw()
+                        .as_mut()
+                        .unwrap_throw()
+                        .pull(controller)
+                },
+            )
+        };
+        raw.set_pull(pull.into_js_value().unchecked_ref());
+
+        let cancel = Closure::<dyn FnMut()>::new(move || {
+            // The stream has been canceled, drop everything.
+            *source.try_borrow_mut().unwrap_throw() = None;
+        });
+        raw.set_cancel(cancel.into_js_value().unchecked_ref());
+
+        raw
     }
 
-    #[wasm_bindgen(getter, js_name = autoAllocateChunkSize)]
-    pub fn auto_allocate_chunk_size(&self) -> usize {
-        self.default_buffer_len
-    }
-
-    pub fn start(&mut self, controller: sys::ReadableByteStreamController) {
+    fn start(&mut self, controller: sys::ReadableByteStreamController) {
         self.controller = Some(controller);
     }
 
-    pub fn pull(&mut self, controller: sys::ReadableByteStreamController) -> Promise {
+    #[allow(clippy::await_holding_refcell_ref)]
+    fn pull(&mut self, controller: sys::ReadableByteStreamController) -> Promise {
         let inner = self.inner.clone();
         let fut = async move {
             // This mutable borrow can never panic, since the ReadableStream always queues
@@ -79,11 +105,6 @@ impl IntoUnderlyingByteSource {
         // leaving it in a clean None state. This prevents use of corrupted state
         // after a panic is caught.
         future_to_promise(AssertUnwindSafe(fut))
-    }
-
-    pub fn cancel(self) {
-        // The stream has been canceled, drop everything.
-        drop(self);
     }
 }
 

--- a/src/readable/into_underlying_byte_source.rs
+++ b/src/readable/into_underlying_byte_source.rs
@@ -42,7 +42,8 @@ impl IntoUnderlyingByteSource {
         let source = Rc::new(RefCell::new(Some(self)));
 
         let start = {
-            let source = source.clone();
+            // SAFETY: start() only stores the controller, which cannot panic.
+            let source = AssertUnwindSafe(source.clone());
             Closure::<dyn FnMut(sys::ReadableByteStreamController)>::new(move |controller| {
                 source
                     .try_borrow_mut()
@@ -55,7 +56,9 @@ impl IntoUnderlyingByteSource {
         raw.set_start(start.into_js_value().unchecked_ref());
 
         let pull = {
-            let source = source.clone();
+            // SAFETY: Inner::pull() uses the take-and-replace pattern to remain
+            // in a clean state if a panic is caught across this closure.
+            let source = AssertUnwindSafe(source.clone());
             Closure::<dyn FnMut(sys::ReadableByteStreamController) -> Promise>::new(
                 move |controller| {
                     // This mutable borrow can never panic, since the ReadableStream
@@ -71,10 +74,14 @@ impl IntoUnderlyingByteSource {
         };
         raw.set_pull(pull.into_js_value().unchecked_ref());
 
-        let cancel = Closure::<dyn FnMut()>::new(move || {
-            // The stream has been canceled, drop everything.
-            *source.try_borrow_mut().unwrap_throw() = None;
-        });
+        let cancel = {
+            // SAFETY: cancel() only drops the source, which cannot panic.
+            let source = AssertUnwindSafe(source);
+            Closure::<dyn FnMut()>::new(move || {
+                // The stream has been canceled, drop everything.
+                *source.try_borrow_mut().unwrap_throw() = None;
+            })
+        };
         raw.set_cancel(cancel.into_js_value().unchecked_ref());
 
         raw

--- a/src/readable/into_underlying_source.rs
+++ b/src/readable/into_underlying_source.rs
@@ -1,11 +1,12 @@
 use std::cell::RefCell;
-use std::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
+use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::rc::Rc;
 
 use futures_util::future::{AbortHandle, TryFutureExt, abortable};
 use futures_util::stream::{Stream, TryStreamExt};
 use js_sys::Promise;
+use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
@@ -13,20 +14,10 @@ use super::sys;
 
 type JsValueStream = dyn Stream<Item = Result<JsValue, JsValue>>;
 
-#[wasm_bindgen]
 pub(crate) struct IntoUnderlyingSource {
     inner: Rc<RefCell<Inner>>,
     pull_handle: Option<AbortHandle>,
 }
-
-// SAFETY: `Inner` holds an `Option<Pin<Box<JsValueStream>>>` and uses the
-// take-and-replace pattern around every fallible await in `Inner::pull`. On
-// panic, the stream is already taken out of the `Option`, leaving the cell in
-// a clean `None` state. Subsequent calls fail cleanly via `unwrap_throw`
-// rather than observing a torn intermediate state, which upholds the logical
-// unwind-safety contract `#[wasm_bindgen]` enforces for exported types.
-impl UnwindSafe for IntoUnderlyingSource {}
-impl RefUnwindSafe for IntoUnderlyingSource {}
 
 impl IntoUnderlyingSource {
     pub fn new(stream: Box<JsValueStream>) -> Self {
@@ -35,12 +26,43 @@ impl IntoUnderlyingSource {
             pull_handle: None,
         }
     }
-}
 
-#[allow(clippy::await_holding_refcell_ref)]
-#[wasm_bindgen]
-impl IntoUnderlyingSource {
-    pub fn pull(&mut self, controller: sys::ReadableStreamDefaultController) -> Promise {
+    /// Converts into a raw [`UnderlyingSource`](sys::UnderlyingSource) object,
+    /// with `pull` and `cancel` backed by imported closures.
+    /// The closures (and thus the source) live as long as the JS object,
+    /// and are deallocated through GC finalization.
+    pub fn into_raw(self) -> sys::UnderlyingSource {
+        let source = Rc::new(RefCell::new(Some(self)));
+        let raw = sys::UnderlyingSource::new();
+
+        let pull = {
+            let source = source.clone();
+            Closure::<dyn FnMut(sys::ReadableStreamDefaultController) -> Promise>::new(
+                move |controller| {
+                    // This mutable borrow can never panic, since the ReadableStream
+                    // always queues each operation on the underlying source.
+                    source
+                        .try_borrow_mut()
+                        .unwrap_throw()
+                        .as_mut()
+                        .unwrap_throw()
+                        .pull(controller)
+                },
+            )
+        };
+        raw.set_pull(pull.into_js_value().unchecked_ref());
+
+        let cancel = Closure::<dyn FnMut()>::new(move || {
+            // The stream has been canceled, drop everything.
+            *source.try_borrow_mut().unwrap_throw() = None;
+        });
+        raw.set_cancel(cancel.into_js_value().unchecked_ref());
+
+        raw
+    }
+
+    #[allow(clippy::await_holding_refcell_ref)]
+    fn pull(&mut self, controller: sys::ReadableStreamDefaultController) -> Promise {
         let inner = self.inner.clone();
         let fut = async move {
             // This mutable borrow can never panic, since the ReadableStream always queues
@@ -60,11 +82,6 @@ impl IntoUnderlyingSource {
         // leaving it in a clean None state. This prevents use of corrupted state
         // after a panic is caught.
         future_to_promise(AssertUnwindSafe(fut))
-    }
-
-    pub fn cancel(self) {
-        // The stream has been canceled, drop everything.
-        drop(self);
     }
 }
 

--- a/src/readable/into_underlying_source.rs
+++ b/src/readable/into_underlying_source.rs
@@ -36,7 +36,9 @@ impl IntoUnderlyingSource {
         let raw = sys::UnderlyingSource::new();
 
         let pull = {
-            let source = source.clone();
+            // SAFETY: Inner::pull() uses the take-and-replace pattern to remain
+            // in a clean state if a panic is caught across this closure.
+            let source = AssertUnwindSafe(source.clone());
             Closure::<dyn FnMut(sys::ReadableStreamDefaultController) -> Promise>::new(
                 move |controller| {
                     // This mutable borrow can never panic, since the ReadableStream
@@ -52,10 +54,14 @@ impl IntoUnderlyingSource {
         };
         raw.set_pull(pull.into_js_value().unchecked_ref());
 
-        let cancel = Closure::<dyn FnMut()>::new(move || {
-            // The stream has been canceled, drop everything.
-            *source.try_borrow_mut().unwrap_throw() = None;
-        });
+        let cancel = {
+            // SAFETY: cancel() only drops the source, which cannot panic.
+            let source = AssertUnwindSafe(source);
+            Closure::<dyn FnMut()>::new(move || {
+                // The stream has been canceled, drop everything.
+                *source.try_borrow_mut().unwrap_throw() = None;
+            })
+        };
         raw.set_cancel(cancel.into_js_value().unchecked_ref());
 
         raw

--- a/src/readable/mod.rs
+++ b/src/readable/mod.rs
@@ -67,13 +67,15 @@ impl ReadableStream {
     where
         St: Stream<Item = Result<JsValue, JsValue>> + 'static,
     {
-        let source = IntoUnderlyingSource::new(Box::new(stream));
+        let source = IntoUnderlyingSource::new(Box::new(stream)).into_raw();
         // Set HWM to 0 to prevent the JS ReadableStream from buffering chunks in its queue,
         // since the original Rust stream is better suited to handle that.
         let strategy = QueuingStrategy::new(0.0);
-        let raw =
-            sys::ReadableStreamExt::new_with_into_underlying_source(source, strategy.into_raw())
-                .unchecked_into();
+        let raw = sys::ReadableStream::new_with_underlying_source_and_strategy(
+            &source,
+            &strategy.into_raw(),
+        )
+        .unwrap_throw();
         Self::from_raw(raw)
     }
 
@@ -93,10 +95,10 @@ impl ReadableStream {
     where
         R: AsyncRead + 'static,
     {
-        let source = IntoUnderlyingByteSource::new(Box::new(async_read), default_buffer_len);
-        let raw = sys::ReadableStreamExt::new_with_into_underlying_byte_source(source)
-            .expect_throw("readable byte streams not supported")
-            .unchecked_into();
+        let source =
+            IntoUnderlyingByteSource::new(Box::new(async_read), default_buffer_len).into_raw();
+        let raw = sys::ReadableStream::new_with_underlying_source(&source)
+            .expect_throw("readable byte streams not supported");
         Self::from_raw(raw)
     }
 

--- a/src/readable/sys.rs
+++ b/src/readable/sys.rs
@@ -15,27 +15,13 @@ pub use web_sys::ReadableStreamReadResult;
 pub use web_sys::ReadableStreamReaderMode;
 pub use web_sys::ReadableStreamType;
 pub use web_sys::StreamPipeOptions as PipeOptions;
-
-use crate::queuing_strategy::sys::QueuingStrategy;
-use crate::readable::into_underlying_byte_source::IntoUnderlyingByteSource;
-use crate::readable::into_underlying_source::IntoUnderlyingSource;
+pub use web_sys::UnderlyingSource;
 
 #[wasm_bindgen]
 extern "C" {
     /// Additional methods for [`ReadableStream`](web_sys::ReadableStream).
     #[wasm_bindgen(js_name = ReadableStream, typescript_type = "ReadableStream")]
     pub(crate) type ReadableStreamExt;
-
-    #[wasm_bindgen(constructor, js_class = ReadableStream)]
-    pub(crate) fn new_with_into_underlying_source(
-        source: IntoUnderlyingSource,
-        strategy: QueuingStrategy,
-    ) -> ReadableStreamExt;
-
-    #[wasm_bindgen(constructor, catch, js_class = ReadableStream)]
-    pub(crate) fn new_with_into_underlying_byte_source(
-        source: IntoUnderlyingByteSource,
-    ) -> Result<ReadableStreamExt, Error>;
 
     #[wasm_bindgen(method, catch, js_class = ReadableStream, js_name = getReader)]
     pub(crate) fn try_get_reader(this: &ReadableStreamExt) -> Result<Object, Error>;

--- a/src/writable/into_underlying_sink.rs
+++ b/src/writable/into_underlying_sink.rs
@@ -1,27 +1,19 @@
 use std::cell::RefCell;
-use std::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
+use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::rc::Rc;
 
 use futures_util::{Sink, SinkExt};
 use js_sys::Promise;
+use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
-#[wasm_bindgen]
+use super::sys;
+
 pub(crate) struct IntoUnderlyingSink {
     inner: Rc<RefCell<Inner>>,
 }
-
-// SAFETY: `Inner` holds an `Option<Pin<Box<dyn Sink<...>>>>` and uses the
-// take-and-replace pattern around every fallible await in `Inner::write` /
-// `Inner::close` / `Inner::abort`. On panic the sink is already taken out of
-// the `Option`, leaving the cell in a clean `None` state. The
-// `Rc<RefCell<Inner>>` interior mutability therefore cannot expose torn
-// invariants after a caught panic, upholding the logical unwind-safety
-// contract enforced by `#[wasm_bindgen]` exports under `panic = "unwind"`.
-impl UnwindSafe for IntoUnderlyingSink {}
-impl RefUnwindSafe for IntoUnderlyingSink {}
 
 impl IntoUnderlyingSink {
     pub fn new(sink: Box<dyn Sink<JsValue, Error = JsValue>>) -> Self {
@@ -29,12 +21,55 @@ impl IntoUnderlyingSink {
             inner: Rc::new(RefCell::new(Inner::new(sink))),
         }
     }
-}
 
-#[allow(clippy::await_holding_refcell_ref)]
-#[wasm_bindgen]
-impl IntoUnderlyingSink {
-    pub fn write(&mut self, chunk: JsValue) -> Promise {
+    /// Converts into a raw [`UnderlyingSink`](sys::UnderlyingSink) object,
+    /// with `write`, `close` and `abort` backed by imported closures.
+    /// The closures (and thus the sink) live as long as the JS object,
+    /// and are deallocated through GC finalization.
+    pub fn into_raw(self) -> sys::UnderlyingSink {
+        let sink = Rc::new(RefCell::new(Some(self)));
+        let raw = sys::UnderlyingSink::new();
+
+        let write = {
+            let sink = sink.clone();
+            Closure::<dyn FnMut(JsValue) -> Promise>::new(move |chunk| {
+                // This mutable borrow can never panic, since the WritableStream
+                // always queues each operation on the underlying sink.
+                sink.try_borrow_mut()
+                    .unwrap_throw()
+                    .as_mut()
+                    .unwrap_throw()
+                    .write(chunk)
+            })
+        };
+        raw.set_write(write.into_js_value().unchecked_ref());
+
+        let close = {
+            let sink = sink.clone();
+            Closure::<dyn FnMut() -> Promise>::new(move || {
+                sink.try_borrow_mut()
+                    .unwrap_throw()
+                    .take()
+                    .unwrap_throw()
+                    .close()
+            })
+        };
+        raw.set_close(close.into_js_value().unchecked_ref());
+
+        let abort = Closure::<dyn FnMut(JsValue) -> Promise>::new(move |reason| {
+            sink.try_borrow_mut()
+                .unwrap_throw()
+                .take()
+                .unwrap_throw()
+                .abort(reason)
+        });
+        raw.set_abort(abort.into_js_value().unchecked_ref());
+
+        raw
+    }
+
+    #[allow(clippy::await_holding_refcell_ref)]
+    fn write(&mut self, chunk: JsValue) -> Promise {
         let inner = self.inner.clone();
         // SAFETY: We use the take-and-replace pattern in Inner::write() to ensure
         // that if a panic occurs, the sink is already taken out of the Option,
@@ -48,7 +83,8 @@ impl IntoUnderlyingSink {
         }))
     }
 
-    pub fn close(self) -> Promise {
+    #[allow(clippy::await_holding_refcell_ref)]
+    fn close(self) -> Promise {
         // SAFETY: Inner::close() takes the sink before the fallible operation.
         future_to_promise(AssertUnwindSafe(async move {
             let mut inner = self.inner.try_borrow_mut().unwrap_throw();
@@ -56,7 +92,8 @@ impl IntoUnderlyingSink {
         }))
     }
 
-    pub fn abort(self, reason: JsValue) -> Promise {
+    #[allow(clippy::await_holding_refcell_ref)]
+    fn abort(self, reason: JsValue) -> Promise {
         // SAFETY: Inner::abort() just sets sink to None, no fallible operation.
         future_to_promise(AssertUnwindSafe(async move {
             let mut inner = self.inner.try_borrow_mut().unwrap_throw();

--- a/src/writable/into_underlying_sink.rs
+++ b/src/writable/into_underlying_sink.rs
@@ -31,7 +31,9 @@ impl IntoUnderlyingSink {
         let raw = sys::UnderlyingSink::new();
 
         let write = {
-            let sink = sink.clone();
+            // SAFETY: Inner::write() uses the take-and-replace pattern to remain
+            // in a clean state if a panic is caught across this closure.
+            let sink = AssertUnwindSafe(sink.clone());
             Closure::<dyn FnMut(JsValue) -> Promise>::new(move |chunk| {
                 // This mutable borrow can never panic, since the WritableStream
                 // always queues each operation on the underlying sink.
@@ -45,7 +47,8 @@ impl IntoUnderlyingSink {
         raw.set_write(write.into_js_value().unchecked_ref());
 
         let close = {
-            let sink = sink.clone();
+            // SAFETY: close() takes the sink out before any fallible operation.
+            let sink = AssertUnwindSafe(sink.clone());
             Closure::<dyn FnMut() -> Promise>::new(move || {
                 sink.try_borrow_mut()
                     .unwrap_throw()
@@ -56,13 +59,17 @@ impl IntoUnderlyingSink {
         };
         raw.set_close(close.into_js_value().unchecked_ref());
 
-        let abort = Closure::<dyn FnMut(JsValue) -> Promise>::new(move |reason| {
-            sink.try_borrow_mut()
-                .unwrap_throw()
-                .take()
-                .unwrap_throw()
-                .abort(reason)
-        });
+        let abort = {
+            // SAFETY: abort() only drops the sink, which cannot panic.
+            let sink = AssertUnwindSafe(sink);
+            Closure::<dyn FnMut(JsValue) -> Promise>::new(move |reason| {
+                sink.try_borrow_mut()
+                    .unwrap_throw()
+                    .take()
+                    .unwrap_throw()
+                    .abort(reason)
+            })
+        };
         raw.set_abort(abort.into_js_value().unchecked_ref());
 
         raw

--- a/src/writable/mod.rs
+++ b/src/writable/mod.rs
@@ -51,10 +51,10 @@ impl WritableStream {
     where
         Si: Sink<JsValue, Error = JsValue> + 'static,
     {
-        let sink = IntoUnderlyingSink::new(Box::new(sink));
+        let sink = IntoUnderlyingSink::new(Box::new(sink)).into_raw();
         // Use the default queuing strategy (with a HWM of 1 chunk).
         // We shouldn't set HWM to 0, since that would break piping to the writable stream.
-        let raw = sys::WritableStreamExt::new_with_into_underlying_sink(sink).unchecked_into();
+        let raw = sys::WritableStream::new_with_underlying_sink(&sink).unwrap_throw();
         Self::from_raw(raw)
     }
 

--- a/src/writable/sys.rs
+++ b/src/writable/sys.rs
@@ -1,19 +1,6 @@
 //! Raw bindings to JavaScript objects used
 //! by a [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
 //! These are re-exported from [web-sys](https://docs.rs/web-sys/0.3.70/web_sys/struct.WritableStream.html).
-use wasm_bindgen::prelude::*;
+pub use web_sys::UnderlyingSink;
 pub use web_sys::WritableStream;
 pub use web_sys::WritableStreamDefaultWriter;
-
-use crate::writable::into_underlying_sink::IntoUnderlyingSink;
-
-#[wasm_bindgen]
-extern "C" {
-    /// A raw [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
-    #[wasm_bindgen(js_name = WritableStream, typescript_type = "WritableStream")]
-    #[derive(Clone, Debug)]
-    pub(crate) type WritableStreamExt;
-
-    #[wasm_bindgen(constructor, js_class = WritableStream)]
-    pub(crate) fn new_with_into_underlying_sink(sink: IntoUnderlyingSink) -> WritableStreamExt;
-}


### PR DESCRIPTION
This refactors `IntoUnderlyingSource`, `IntoUnderlyingByteSource` and `IntoUnderlyingSink` to no longer be `#[wasm_bindgen]` exported classes, instead constructing the underlying source/sink objects through wasm-bindgen imports.

Because these types were exported classes, they leaked into the generated JS glue and `.d.ts` of every downstream crate using wasm-streams, despite being `pub(crate)` implementation details on the Rust side. Building them as plain JS dictionary objects with imported closures keeps the wasm module interface clean and removes the generated class shims entirely.

What was implemented:

* The three structs lose their `#[wasm_bindgen]` export attributes and instead gain an `into_raw()` that builds a `web_sys::UnderlyingSource` / `web_sys::UnderlyingSink` dictionary (features already enabled), with `pull`/`cancel`/`start`/`write`/`close`/`abort` backed by `Closure::into_js_value()` closures over an `Rc<RefCell<Option<Self>>>` slot. Methods taking `self` by value (`cancel`, `close`, `abort`) `take()` from the slot, preserving the existing consume-on-call semantics.
* The custom `ReadableStreamExt`/`WritableStreamExt` constructors are replaced by the standard `web_sys` constructors taking the dictionary objects.
* The manual `UnwindSafe`/`RefUnwindSafe` impls from #35 are no longer needed since the types are no longer exports; the take-and-replace pattern and `AssertUnwindSafe` future wrappers are preserved unchanged.

Before:

```rs
#[wasm_bindgen]
pub(crate) struct IntoUnderlyingSource { ... }
```

After:

```rs
pub(crate) struct IntoUnderlyingSource { ... }

impl IntoUnderlyingSource {
    pub fn into_raw(self) -> sys::UnderlyingSource { ... }
}
```

Memory semantics are equivalent: exported class instances were freed via `FinalizationRegistry` when unreachable, and `into_js_value()` closures use the same mechanism. The JS-observable stream behavior is unchanged (`type`/`autoAllocateChunkSize` become plain data properties rather than getters, with identical values), so this should be non-breaking; the only downstream-visible effect is the removal of the incidental class exports from generated bindings.

Existing tests (including the panic=unwind suite) cover the refactored paths.

_Made with AI assistance under my review_