### PR TITLE
Build only the rlib crate type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Removed the `cdylib` crate type. The crate is only consumed as a Rust library, and the extra shared-library link was built for every dependent. Use `cargo rustc --crate-type cdylib` to build a standalone module.
+
 ## v0.6.0 (2026-05-24)
 
 * Updated to Rust edition 2024. The minimum supported Rust version (MSRV) is now 1.88.0. ([#34](https://github.com/MattiasBuelens/wasm-streams/pull/34), [#37](https://github.com/MattiasBuelens/wasm-streams/pull/37))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ exclude = [
     ".github/",
 ]
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-
 [dependencies]
 js-sys = "^0.3.85"
 wasm-bindgen = "0.2.108"


### PR DESCRIPTION
This removes `cdylib` from the crate types so only the default `rlib` is built, fixing an issue where `--target wasm32-unknown-emscripten` would fail to link due to selecting the `cdylib` build type instead for wasm-streams.

While the `cdylib` was originally added for `wasm-pack build`, CI only uses `wasm-pack test`, which does not need it. See rust-lang/cargo#11232 and hyperium/hyper#2770 for the same change in hyper.

* Drop the `[lib] crate-type` override; `rlib` is the default
* Add an Unreleased changelog entry

A standalone module can still be built on demand:

```sh
cargo rustc --lib --target wasm32-unknown-unknown --crate-type cdylib
```

Verified `wasm-pack test --node` (48 tests) passes and the command above still emits `wasm_streams.wasm`.